### PR TITLE
feat: Tier 2 state health monitoring for hidden state poisoning (KHA-173)

### DIFF
--- a/docs/stateful_mamba/state_validation.md
+++ b/docs/stateful_mamba/state_validation.md
@@ -150,13 +150,15 @@ The four pipeline integration points (`save_snapshot`, `load_snapshot`, `inject_
 
 ---
 
-## Future: Tier 2 Monitoring
+## Tier 2: State Health Monitoring
 
-The current checks (Tier 1) are binary pass/fail. A planned Tier 2 layer would add statistical monitoring:
+Beyond binary pass/fail (Tier 1), the `StateHealthMonitor` provides statistical anomaly detection:
 
-- **Tensor norm tracking.** Compute L2 norm of `temporal_states` after each forward pass and maintain a rolling baseline per conversation.
-- **Anomaly detection.** Flag states where the norm deviates more than 3 standard deviations from the baseline. This catches drift that does not produce NaN/Inf but is nonetheless pathological.
-- **Configurable interval.** Controlled via `--snapshot-health-check-interval N` (check every N turns). Default: disabled.
-- **Failure policy.** Two modes under consideration: `log_and_continue` (warn but proceed) vs `kill_session` (invalidate the conversation's WARM entry and force cold restore on next turn). This is a product decision — `kill_session` is safer but may surprise users with unexpected context resets.
-
-Tier 2 monitoring has no implementation in the current codebase. The `ValidationResult.warnings` list is the intended channel for surfacing Tier 2 findings without blocking inference.
+- **Per-layer norm tracking.** Computes L2 norm of each layer in `conv_states` and `temporal_states` after each forward pass, maintaining a rolling baseline per conversation via `NormBaseline`.
+- **Anomaly detection.** Flags layers where the norm deviates beyond a configurable sigma threshold (default: 3σ) from the rolling baseline. Anomalous values are excluded from the baseline to prevent poisoning.
+- **Configurable interval.** Controlled via `--snapshot-health-check-interval N` (check every N snapshots). `0` = disabled (default).
+- **Failure policy.** Two modes via `--snapshot-health-failure-policy`:
+  - `log_and_continue` (default) — log a warning and save the snapshot anyway.
+  - `skip_snapshot` — skip saving the snapshot for this turn.
+- **Scheduler integration.** Wired into the post-forward snapshot callback. Health checks gate persistence — they only run when a snapshot is about to be saved. Baselines are automatically reset after a snapshot restore to avoid false anomalies.
+- **Non-blocking.** Warnings do not block inference. The health check runs inline but its failure modes only affect snapshot persistence, never request processing.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1107,13 +1107,6 @@ class Scheduler(
                             )
                             if policy == "skip_snapshot":
                                 return
-                            elif policy == "kill_session":
-                                # TODO: product decision — stub for now
-                                logger.warning(
-                                    "kill_session policy not yet implemented, "
-                                    "falling back to skip_snapshot"
-                                )
-                                return
                             # else: log_and_continue — fall through to save
                 except Exception:
                     logger.error(
@@ -1679,6 +1672,11 @@ class Scheduler(
                         f"stateful_generate={stateful_generate}"
                     )
 
+                    # Reset health baselines after restore to avoid false anomalies
+                    if self.state_health_monitor is not None:
+                        self.state_health_monitor.reset_baseline(effective_conv_id)
+                        self._health_check_counter[effective_conv_id] = 0
+
                     if stateful_generate:
                         # Output will be sent after generation completes via the
                         # _stateful_generate hook in scheduler_output_processor_mixin.
@@ -1815,6 +1813,11 @@ class Scheduler(
             )
             req.origin_input_ids = metadata.fill_ids  # keep as list for downstream code
             logger.info(f"Synced fill_ids after restore, len={len(metadata.fill_ids)}")
+
+            # Reset health baselines after restore to avoid false anomalies
+            if self.state_health_monitor is not None:
+                self.state_health_monitor.reset_baseline(effective_conv_id)
+                self._health_check_counter[effective_conv_id] = 0
 
             logger.info(
                 f"Snapshot restored: conversation={recv_req.conversation_id}, "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5103,6 +5103,12 @@ class ServerArgs:
         )
 
         # Mamba state persistence (snapshot system)
+        def _nonneg_int(value):
+            ivalue = int(value)
+            if ivalue < 0:
+                raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+            return ivalue
+
         parser.add_argument(
             "--enable-snapshot-persistence",
             action="store_true",
@@ -5162,14 +5168,14 @@ class ServerArgs:
         )
         parser.add_argument(
             "--snapshot-health-check-interval",
-            type=int,
+            type=_nonneg_int,
             default=ServerArgs.snapshot_health_check_interval,
             help="Run state health check every N snapshots. 0 = disabled (default: 0).",
         )
         parser.add_argument(
             "--snapshot-health-failure-policy",
             type=str,
-            choices=["log_and_continue", "skip_snapshot", "kill_session"],
+            choices=["log_and_continue", "skip_snapshot"],
             default=ServerArgs.snapshot_health_failure_policy,
             help="Action when health anomaly detected (default: log_and_continue).",
         )

--- a/python/sglang/srt/snapshot/__init__.py
+++ b/python/sglang/srt/snapshot/__init__.py
@@ -24,9 +24,19 @@ Key Components:
 from sglang.srt.snapshot.mamba_snapshot import (
     MambaSnapshotManager,
     MambaSnapshotMetadata,
+    SnapshotValidationError,
     ValidationResult,
     validate_state_tensors,
 )
+
+__all__ = [
+    # Phase 2: Core snapshots
+    "MambaSnapshotManager",
+    "MambaSnapshotMetadata",
+    "SnapshotValidationError",
+    "ValidationResult",
+    "validate_state_tensors",
+]
 
 try:
     from sglang.srt.snapshot.conversation_tracker import (
@@ -39,26 +49,21 @@ try:
     from sglang.srt.snapshot.snapshot_policy import SnapshotRetentionPolicy
     from sglang.srt.snapshot.state_health import HealthCheckResult, StateHealthMonitor
     from sglang.srt.snapshot.tier_manager import TierManager
+
+    __all__.extend([
+        "SnapshotHookManager",
+        "SnapshotRetentionPolicy",
+        # Phase 2.5: Memory tiers
+        "MambaHostPool",
+        "HostPoolEntry",
+        "ConversationTracker",
+        "ConversationTier",
+        "ConversationState",
+        "TierManager",
+        # Tier 2: State health monitoring
+        "StateHealthMonitor",
+        "HealthCheckResult",
+    ])
 except ImportError:
     # Allow partial imports during development
     pass
-
-__all__ = [
-    # Phase 2: Core snapshots
-    "MambaSnapshotManager",
-    "MambaSnapshotMetadata",
-    "ValidationResult",
-    "validate_state_tensors",
-    "SnapshotHookManager",
-    "SnapshotRetentionPolicy",
-    # Phase 2.5: Memory tiers
-    "MambaHostPool",
-    "HostPoolEntry",
-    "ConversationTracker",
-    "ConversationTier",
-    "ConversationState",
-    "TierManager",
-    # Tier 2: State health monitoring
-    "StateHealthMonitor",
-    "HealthCheckResult",
-]

--- a/python/sglang/srt/snapshot/mamba_snapshot.py
+++ b/python/sglang/srt/snapshot/mamba_snapshot.py
@@ -17,6 +17,11 @@ from safetensors.torch import load_file, save_file
 logger = logging.getLogger(__name__)
 
 
+class SnapshotValidationError(ValueError):
+    """Raised when snapshot state fails validation checks."""
+    pass
+
+
 @dataclass
 class MambaSnapshotMetadata:
     """
@@ -501,7 +506,7 @@ class MambaSnapshotManager:
                 f"{'; '.join(result.errors)}"
             )
             logger.error(error_msg)
-            raise ValueError(error_msg)
+            raise SnapshotValidationError(error_msg)
         for w in result.warnings:
             logger.warning(f"State validation warning (load): {w}")
 

--- a/python/sglang/srt/snapshot/state_health.py
+++ b/python/sglang/srt/snapshot/state_health.py
@@ -140,49 +140,62 @@ class StateHealthMonitor:
         anomalous_layers: List[int] = []
         details: Dict[int, dict] = {}
 
-        # Check conv_states (one tensor per layer group)
-        for layer_idx, tensor in enumerate(conv_states):
-            norm = torch.linalg.norm(tensor.float()).item()
+        # Track layer index across all state tensors
+        layer_idx = 0
+
+        # Check conv_states — iterate over the leading (layer) dimension
+        for tensor in conv_states:
+            num_layers = tensor.shape[0]
+            for i in range(num_layers):
+                norm = torch.linalg.norm(tensor[i].float()).item()
+                is_anomalous = baseline.is_anomalous(
+                    layer_idx, norm, self._sigma_threshold
+                )
+                mean, std, count = baseline.get_stats(layer_idx)
+
+                if is_anomalous:
+                    anomalous_layers.append(layer_idx)
+                    sigma_dev = abs(norm - mean) / std if std > 0 else float("inf")
+                    details[layer_idx] = {
+                        "norm": norm,
+                        "mean": mean,
+                        "std": std,
+                        "sigma_deviation": sigma_dev,
+                        "source": "conv_state",
+                    }
+                else:
+                    # Only update baseline with non-anomalous values
+                    baseline.update(layer_idx, norm)
+
+                layer_idx += 1
+
+        # Check temporal_states — iterate over the leading (layer) dimension
+        num_temporal_layers = temporal_states.shape[0]
+        for i in range(num_temporal_layers):
+            norm = torch.linalg.norm(temporal_states[i].float()).item()
             is_anomalous = baseline.is_anomalous(
                 layer_idx, norm, self._sigma_threshold
             )
             mean, std, count = baseline.get_stats(layer_idx)
-            baseline.update(layer_idx, norm)
 
             if is_anomalous:
                 anomalous_layers.append(layer_idx)
-                sigma_dev = abs(norm - mean) / std if std > 0 else float("inf")
+                sigma_dev = (
+                    abs(norm - mean) / std
+                    if std > 0
+                    else float("inf")
+                )
                 details[layer_idx] = {
                     "norm": norm,
                     "mean": mean,
                     "std": std,
                     "sigma_deviation": sigma_dev,
-                    "source": "conv_state",
+                    "source": "temporal_states",
                 }
+            else:
+                baseline.update(layer_idx, norm)
 
-        # Check temporal_states as a single aggregate
-        temporal_layer_idx = len(conv_states)
-        temporal_norm = torch.linalg.norm(temporal_states.float()).item()
-        is_temporal_anomalous = baseline.is_anomalous(
-            temporal_layer_idx, temporal_norm, self._sigma_threshold
-        )
-        t_mean, t_std, t_count = baseline.get_stats(temporal_layer_idx)
-        baseline.update(temporal_layer_idx, temporal_norm)
-
-        if is_temporal_anomalous:
-            anomalous_layers.append(temporal_layer_idx)
-            sigma_dev = (
-                abs(temporal_norm - t_mean) / t_std
-                if t_std > 0
-                else float("inf")
-            )
-            details[temporal_layer_idx] = {
-                "norm": temporal_norm,
-                "mean": t_mean,
-                "std": t_std,
-                "sigma_deviation": sigma_dev,
-                "source": "temporal_states",
-            }
+            layer_idx += 1
 
         return HealthCheckResult(
             healthy=len(anomalous_layers) == 0,

--- a/python/sglang/srt/snapshot/tier_manager.py
+++ b/python/sglang/srt/snapshot/tier_manager.py
@@ -81,8 +81,8 @@ def restore_latest_snapshots_to_warm_tier(
             )
         except ValueError as e:
             active_logger.warning(
-                "Quarantined snapshot for conversation %s: state validation "
-                "failed during startup restore: %s",
+                "Quarantined snapshot for conversation %s: "
+                "failed to restore during startup: %s",
                 conv_id,
                 e,
             )

--- a/python/sglang/test/srt/test_snapshot_validation.py
+++ b/python/sglang/test/srt/test_snapshot_validation.py
@@ -10,6 +10,7 @@ from sglang.srt.snapshot.mamba_snapshot import (
     ALLOWED_DTYPES,
     MambaSnapshotManager,
     MambaSnapshotMetadata,
+    SnapshotValidationError,
     ValidationResult,
     validate_state_tensors,
 )
@@ -292,5 +293,5 @@ def test_save_load_roundtrip_and_quarantine():
         for f in snapshot_files:
             f.write_bytes(b"corrupted data")
 
-        with pytest.raises((ValueError, Exception)):
+        with pytest.raises(SnapshotValidationError):
             manager.load_snapshot("roundtrip-conv", turn_number=0)

--- a/python/sglang/test/srt/test_state_health.py
+++ b/python/sglang/test/srt/test_state_health.py
@@ -101,8 +101,9 @@ def test_health_monitor_single_layer_anomaly():
         temporal = _make_temporal_states(scale=1.0)
         monitor.check_state_health("conv-1", conv, temporal, turn_number=i)
 
-    # Spike conv_states by 100x
-    conv_spike = _make_conv_states(scale=100.0)
+    # Spike only layer 0 of conv_states
+    conv_spike = _make_conv_states(scale=1.0)
+    conv_spike[0][0] *= 100.0  # spike layer 0 only
     temporal_normal = _make_temporal_states(scale=1.0)
     result = monitor.check_state_health("conv-1", conv_spike, temporal_normal, turn_number=20)
 


### PR DESCRIPTION
## Summary

- Adds `StateHealthMonitor` with rolling per-layer norm baselines and sigma-threshold anomaly detection (`state_health.py`)
- Two new server args: `--snapshot-health-check-interval N` and `--snapshot-health-failure-policy` (log_and_continue | skip_snapshot | kill_session)
- Hooks into `post_forward_snapshot_callback` with per-conversation snapshot counter for interval tracking
- Structural validation (Tier 1) runs first inside health check — NaN/Inf short-circuits norm analysis
- `kill_session` stubbed as TODO (product decision)
- 10 CPU-only unit tests

Builds on PR #25 (Tier 1 guards). Both tiers together provide defense-in-depth against hidden state poisoning in the persistent snapshot system.

## Test plan

- [ ] `pytest python/sglang/test/srt/test_state_health.py -v` (needs GPU instance with sglang installed)
- [ ] `pytest python/sglang/test/srt/test_snapshot_validation.py -v` (no regressions on Tier 1)
- [ ] Live server test with `--snapshot-health-check-interval 1` and adversarial prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * State validation for Mamba snapshots that blocks persistence/restore on corrupted or invalid hidden state
  * Tier‑2 state health monitoring with per‑conversation baselines and anomaly detection
  * Model compatibility checks to prevent restoring snapshots for different models
  * CLI flags to configure snapshot health check interval and failure policy

* **Documentation**
  * Detailed guide on state validation, quarantine behavior, and validation API

* **Tests**
  * New unit and integration tests covering validation, quarantine, and health monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->