### PR TITLE
[codex] keep upstream sync dry runs read-only

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -273,6 +273,7 @@ jobs:
         if: >
           steps.drift.outputs.skip == 'false'
           && steps.merge.outputs.merge_clean == 'false'
+          && inputs.dry_run != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -336,3 +337,16 @@ jobs:
           echo "| Risk level | ${{ steps.classify.outputs.risk_level }} |" >> $GITHUB_STEP_SUMMARY
           echo "| PR created | ${{ steps.create-pr.outputs.pr_url || 'N/A' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dry run | ${{ inputs.dry_run || 'false' }} |" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.merge.outputs.merge_clean }}" = "false" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Conflicting files" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.merge.outputs.conflicts }}" | tr '|' '\n' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+
+            if [ "${{ inputs.dry_run || 'false' }}" = "true" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "_Dry run: conflict issue creation skipped._" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi


### PR DESCRIPTION
## What changed
- skip creating the conflict-report issue when `dry_run=true`
- include the conflicting file list in the workflow summary so dry runs still surface the result

## Why
A manual dry run on `main` correctly detected real upstream merge conflicts, but it also created a real GitHub issue. That makes dry runs noisy and side-effectful when they should be safe probes.

## Impact
- scheduled/manual non-dry runs behave the same as before
- dry runs still attempt the merge and classify risk
- dry runs now report conflicts in the run summary without creating an issue

## Validation
- `git diff --check`
- Ruby YAML parse of `.github/workflows/upstream-sync.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved upstream synchronization workflow with enhanced merge conflict detection and reporting. Added support for dry-run mode to preview potential conflicts without executing merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->