### PR TITLE
fix(ci): validate-sync.sh launches server with every_turn snapshot policy (KHA-352)

### DIFF
--- a/scripts/validate-sync.sh
+++ b/scripts/validate-sync.sh
@@ -76,7 +76,7 @@ python -m sglang.launch_server \
     --port "$PORT" \
     --enable-snapshot-persistence \
     --snapshot-dir "$SNAPSHOT_DIR" \
-    --snapshot-trigger-policy manual_only \
+    --snapshot-trigger-policy every_turn \
     --mem-fraction-static 0.80 \
     --disable-cuda-graph \
     > "$LOG_DIR/server.log" 2>&1 &


### PR DESCRIPTION
Closes KHA-352. Unblocks PR triage cascade smoke tests.

## Background

H100 post-merge validation of PR #60 surfaced this. The script defaults to manual_only snapshot policy, causing /save_snapshot to return HTTP 200 with success:false (no WARM tier state). PR #60's follow-up commit's stricter HTTP-status check correctly caught it.

## Fix

Launch the server with --snapshot-trigger-policy every_turn. Reference test runs that worked with every_turn: KHA-215 Codestral, KHA-338 Nemotron.

## H100 smoke test pending

Requires H100 with model loaded. Expected post-fix: 4/5 PASS, Test 4 stateful recall fails as KHA-348 (chat-completions state rehydration, separate ticket).

## Out of scope

Subsystem ergonomics question (whether save_snapshot should auto-promote HOT to WARM regardless of policy) is filed separately at KHA-353.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test configuration for server startup snapshot persistence settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->