### PR TITLE
fix(snapshot): pending-restore registry surfaces restored state to /v1/chat/completions

### DIFF
--- a/python/sglang/_triton_stub.py
+++ b/python/sglang/_triton_stub.py
@@ -221,6 +221,9 @@ def install() -> None:
     td = _make_mock("triton.tools.tensor_descriptor")
     tools.tensor_descriptor = td
 
+    # triton.compiler  (used by torch._inductor.runtime.triton_compat)
+    triton.compiler = _make_mock("triton.compiler")
+
     # triton.backends / triton.backends.compiler  (used by torch._inductor)
     backends = _make_mock("triton.backends")
     triton.backends = backends

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1466,6 +1466,21 @@ class Scheduler(
             if target == canonical:
                 del self.pending_restore_aliases[alias_key]
 
+        # Case B: canonical (rid) was previously an alias for some other
+        # canonical. Evict that other canonical + all aliases targeting it
+        # so the new canonical insertion doesn't leave a stale entry
+        # reachable via direct rid lookup on that other canonical's key.
+        if canonical in self.pending_restore_aliases:
+            other_canonical = self.pending_restore_aliases[canonical]
+            if (
+                other_canonical != canonical
+                and other_canonical in self.pending_restore_registry
+            ):
+                self.pending_restore_registry.pop(other_canonical)
+            for alias_key, target in list(self.pending_restore_aliases.items()):
+                if target == other_canonical:
+                    del self.pending_restore_aliases[alias_key]
+
         # Insert canonical
         entry = PendingRestoreEntry(
             conv_states=conv_states,
@@ -1485,6 +1500,19 @@ class Scheduler(
                 for alias_key, target in list(self.pending_restore_aliases.items()):
                     if target == conversation_id:
                         del self.pending_restore_aliases[alias_key]
+
+            # Finding 3: conv_id was previously an alias for some other
+            # canonical. Evict that other canonical + all aliases targeting
+            # it so the stale entry isn't left reachable via direct rid
+            # lookup on that old canonical's key.
+            old_canonical = self.pending_restore_aliases.get(conversation_id)
+            if old_canonical is not None and old_canonical != canonical:
+                if old_canonical in self.pending_restore_registry:
+                    self.pending_restore_registry.pop(old_canonical)
+                for alias_key, target in list(self.pending_restore_aliases.items()):
+                    if target == old_canonical:
+                        del self.pending_restore_aliases[alias_key]
+
             self.pending_restore_aliases[conversation_id] = canonical
 
         # Eviction: bound applies to canonical (logical) entries

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1047,14 +1047,17 @@ class Scheduler(
         self.state_health_monitor = None
         self._health_check_counter = {}  # conversation_id → snapshot count
 
-        # Pending-restore registry: rid (and conversation_id alias) → loaded
-        # snapshot state staged for the next incoming request. Populated by
-        # handle_restore_snapshot when the originating Req has already finished;
-        # consumed by _maybe_hydrate_from_pending_restore during request
-        # creation. Bounded by PENDING_RESTORE_REGISTRY_MAX with LRU eviction.
+        # Pending-restore registry: canonical rid → loaded snapshot state staged
+        # for the next incoming request. Populated by handle_restore_snapshot when
+        # the originating Req has already finished; consumed by
+        # _maybe_hydrate_from_pending_restore during request creation. Bounded by
+        # PENDING_RESTORE_REGISTRY_MAX on logical (canonical) entries with LRU
+        # eviction. conversation_id aliases are tracked separately in
+        # pending_restore_aliases so replacement and eviction remain atomic.
         self.pending_restore_registry: "OrderedDict[str, PendingRestoreEntry]" = (
             OrderedDict()
         )
+        self.pending_restore_aliases: "Dict[str, str]" = {}  # alias → canonical rid
 
         # Only initialize if snapshot persistence is enabled
         if not server_args.enable_snapshot_persistence:
@@ -1442,13 +1445,28 @@ class Scheduler(
     ) -> None:
         """Stash a loaded snapshot in the pending-restore registry.
 
-        Indexed by both rid and conversation_id so a follow-up request can hit
-        on either key. Bounded by PENDING_RESTORE_REGISTRY_MAX with LRU eviction
-        of the oldest entry when capacity is exceeded.
+        Canonical OrderedDict keyed by rid, plus a separate alias map for
+        conversation_id → canonical rid. Bounded by PENDING_RESTORE_REGISTRY_MAX
+        on logical (canonical) entries with LRU eviction.
+
+        Aliases whose value collides with an existing canonical entry evict that
+        canonical first, ensuring one logical entry is never stored under
+        multiple keys.
         """
         if getattr(self, "pending_restore_registry", None) is None:
             return
 
+        canonical = rid
+
+        # Drop any old entry for this canonical key
+        if canonical in self.pending_restore_registry:
+            self.pending_restore_registry.pop(canonical)
+        # Drop any aliases that previously pointed at this canonical
+        for alias_key, target in list(self.pending_restore_aliases.items()):
+            if target == canonical:
+                del self.pending_restore_aliases[alias_key]
+
+        # Insert canonical
         entry = PendingRestoreEntry(
             conv_states=conv_states,
             temporal_states=temporal_states,
@@ -1456,26 +1474,33 @@ class Scheduler(
             conversation_id=conversation_id,
             timestamp=time.time(),
         )
+        self.pending_restore_registry[canonical] = entry
 
-        keys = [rid]
-        if conversation_id and conversation_id != rid:
-            keys.append(conversation_id)
+        # Map conversation_id alias if distinct from canonical
+        if conversation_id and conversation_id != canonical:
+            # If conv_id was previously a canonical key for a different entry,
+            # evict that entry first
+            if conversation_id in self.pending_restore_registry:
+                self.pending_restore_registry.pop(conversation_id)
+                for alias_key, target in list(self.pending_restore_aliases.items()):
+                    if target == conversation_id:
+                        del self.pending_restore_aliases[alias_key]
+            self.pending_restore_aliases[conversation_id] = canonical
 
-        for key in keys:
-            if key in self.pending_restore_registry:
-                self.pending_restore_registry.pop(key)
-            self.pending_restore_registry[key] = entry
-
+        # Eviction: bound applies to canonical (logical) entries
         while len(self.pending_restore_registry) > PENDING_RESTORE_REGISTRY_MAX:
-            evicted_key, _ = self.pending_restore_registry.popitem(last=False)
+            evicted_canonical, _ = self.pending_restore_registry.popitem(last=False)
+            for alias_key, target in list(self.pending_restore_aliases.items()):
+                if target == evicted_canonical:
+                    del self.pending_restore_aliases[alias_key]
             logger.debug(
-                "pending-restore registry: evicted oldest entry key=%s "
+                "pending-restore registry: evicted oldest canonical=%s "
                 "(capacity=%d)",
-                evicted_key,
+                evicted_canonical,
                 PENDING_RESTORE_REGISTRY_MAX,
             )
 
-    def _maybe_hydrate_from_pending_restore(self, req) -> bool:
+    def _maybe_hydrate_from_pending_restore(self, req) -> Optional[bool]:
         """Attach restored Mamba state to ``req`` if its rid (or conversation_id)
         has a staged entry in the pending-restore registry.
 
@@ -1485,39 +1510,47 @@ class Scheduler(
         carries the prior conversation history, so prefill processes only the
         new tokens on top of injected state.
 
-        Returns True when state was attached, False otherwise.
+        Returns:
+            None  — no staged entry for this rid/conv_id (true miss, normal flow)
+            True  — staged entry hydrated successfully
+            False — staged entry exists but could not be applied (pool unavailable,
+                    pool full, or inject_state_to_pool raised). Caller MUST surface
+                    this as an error and not proceed with the request, otherwise the
+                    client gets silent fresh-start behavior despite a successful
+                    /restore_snapshot.
         """
         registry = getattr(self, "pending_restore_registry", None)
         if not registry:
-            return False
+            return None
         if getattr(req, "mamba_pool_idx", None) is not None:
-            return False
+            return None
 
         rid = req.rid
         conv_id = getattr(req, "conversation_id", None)
 
-        entry = registry.get(rid)
-        matched_key = rid if entry is not None else None
-        if entry is None and conv_id and conv_id != rid:
-            entry = registry.get(conv_id)
-            matched_key = conv_id if entry is not None else None
-        if entry is None:
-            return False
+        # Lookup: canonical first, then resolve via alias
+        canonical = rid if rid in registry else None
+        if canonical is None and conv_id and conv_id != rid:
+            canonical = self.pending_restore_aliases.get(conv_id)
+        if canonical is None or canonical not in registry:
+            return None
+
+        entry = registry[canonical]
 
         mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
         if mamba_pool is None:
-            logger.warning(
+            logger.error(
                 "pending-restore registry hit for rid=%s but mamba_pool "
-                "unavailable; skipping hydration",
+                "unavailable; hydration will fail",
                 rid,
             )
             return False
 
         new_pool_idx = mamba_pool.alloc(1)
         if new_pool_idx is None:
-            logger.warning(
+            logger.error(
                 "pending-restore registry hit for rid=%s but no free Mamba "
-                "pool slots; skipping hydration",
+                "pool slots; hydration will fail",
                 rid,
             )
             return False
@@ -1553,17 +1586,10 @@ class Scheduler(
         if not getattr(req, "conversation_id", None):
             req.conversation_id = entry.conversation_id
 
-        # Touch the registry entry to mark it most-recently-used. Entries stay
-        # after consumption so back-to-back requests with the same rid reuse
-        # the staged state without requiring another /restore_snapshot call.
-        if matched_key is not None and matched_key in registry:
-            registry.move_to_end(matched_key)
-        if (
-            entry.conversation_id
-            and entry.conversation_id != matched_key
-            and entry.conversation_id in registry
-        ):
-            registry.move_to_end(entry.conversation_id)
+        # Touch the canonical entry to mark it most-recently-used.
+        # Entries stay after consumption so back-to-back requests with the
+        # same rid reuse the staged state without another /restore_snapshot.
+        registry.move_to_end(canonical)
 
         # Reset health baselines so anomaly detection treats restored state
         # as a fresh starting point rather than a divergence from prior live
@@ -1574,9 +1600,9 @@ class Scheduler(
 
         logger.info(
             "pending-restore registry hit: hydrated rid=%s "
-            "(matched_key=%s, conv_id=%s, mamba_pool_idx=%d)",
+            "(canonical=%s, conv_id=%s, mamba_pool_idx=%d)",
             rid,
-            matched_key,
+            canonical,
             entry.conversation_id,
             new_pool_idx_scalar,
         )
@@ -3555,7 +3581,22 @@ class Scheduler(
         # the originating Req had already finished, the loaded state was staged
         # in the pending-restore registry. Hydrate this fresh Req from that
         # entry so the model sees the restored Mamba state at prefill.
-        self._maybe_hydrate_from_pending_restore(req)
+        hydration_result = self._maybe_hydrate_from_pending_restore(req)
+        if hydration_result is False:
+            # Staged entry exists but could not be applied (pool unavailable,
+            # pool full, or inject_state_to_pool raised). Surface as a
+            # request-level error — the client successfully called
+            # /restore_snapshot and has a legitimate expectation that state is
+            # restored.
+            error_msg = (
+                f"Pending-restore hydration failed for rid={req.rid}: "
+                "snapshot was staged but could not be applied (pool exhaustion "
+                "or inject error). Check server logs and pool capacity."
+            )
+            req.set_finish_with_abort(error_msg)
+            self._add_request_to_queue(req)
+            return
+        # None or True: proceed normally
         # --- END ENGRAM ---
 
         # initialize before returning

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -26,7 +26,9 @@ import time
 import uuid
 
 # --- END ENGRAM ---
-from collections import deque
+# --- END ENGRAM ---
+# --- BEGIN ENGRAM: pending restore registry ---
+from collections import OrderedDict, deque
 from contextlib import nullcontext
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -311,6 +313,31 @@ class EmbeddingBatchResult:
                 )
 
         self.copy_done.record()
+
+
+# --- BEGIN ENGRAM: pending restore registry entry + capacity ---
+PENDING_RESTORE_REGISTRY_MAX = 256
+
+
+@dataclass
+class PendingRestoreEntry:
+    """Loaded snapshot state staged for a future incoming request.
+
+    Populated by handle_restore_snapshot when the originating Req has already
+    completed, and consumed by _maybe_hydrate_from_pending_restore on the next
+    incoming Req with a matching rid (or conversation_id alias). The Mamba
+    state is held in CPU host tensors here and moved into a freshly allocated
+    pool slot at consumption time via inject_state_to_pool.
+    """
+
+    conv_states: List[torch.Tensor]
+    temporal_states: torch.Tensor
+    fill_ids: Optional[List[int]]
+    conversation_id: str
+    timestamp: float
+
+
+# --- END ENGRAM ---
 
 
 def validate_dflash_request(req: Req) -> Optional[str]:
@@ -1020,6 +1047,15 @@ class Scheduler(
         self.state_health_monitor = None
         self._health_check_counter = {}  # conversation_id → snapshot count
 
+        # Pending-restore registry: rid (and conversation_id alias) → loaded
+        # snapshot state staged for the next incoming request. Populated by
+        # handle_restore_snapshot when the originating Req has already finished;
+        # consumed by _maybe_hydrate_from_pending_restore during request
+        # creation. Bounded by PENDING_RESTORE_REGISTRY_MAX with LRU eviction.
+        self.pending_restore_registry: "OrderedDict[str, PendingRestoreEntry]" = (
+            OrderedDict()
+        )
+
         # Only initialize if snapshot persistence is enabled
         if not server_args.enable_snapshot_persistence:
             logger.info("Snapshot persistence disabled (standard mode)")
@@ -1339,6 +1375,7 @@ class Scheduler(
             tier_manager=self.tier_manager,
             restore_logger=logger,
         )
+
     # --- END ENGRAM: restore_snapshots_on_startup implementation ---
 
     def _find_request_by_rid(self, rid: str):
@@ -1362,6 +1399,188 @@ class Scheduler(
                 return req
 
         return None
+
+    def _load_snapshot_for_pending_restore(
+        self,
+        conversation_id: str,
+        turn_number: Optional[int],
+        branch_name: Optional[str],
+    ):
+        """Load a snapshot for staging into the pending-restore registry.
+
+        Prefers the WARM tier when no specific turn or branch is requested
+        (latest state, host RAM, ~10-50ms). Falls back to disk for explicit
+        turn/branch selection or when the WARM tier has no entry. Returns
+        (conv_states, temporal_states, metadata) where metadata is a dict from
+        the WARM tier or a MambaSnapshotMetadata from disk, or None when no
+        snapshot is available.
+        """
+        if (
+            self.tier_manager is not None
+            and turn_number is None
+            and branch_name is None
+            and self.tier_manager.host_pool.has_state(conversation_id)
+        ):
+            warm = self.tier_manager.restore_from_warm_tier(conversation_id)
+            if warm is not None:
+                return warm
+
+        try:
+            return self.snapshot_manager.load_snapshot(
+                conversation_id, turn_number, branch_name
+            )
+        except (FileNotFoundError, ValueError):
+            return None
+
+    def _stage_pending_restore(
+        self,
+        rid: str,
+        conversation_id: str,
+        conv_states: List[torch.Tensor],
+        temporal_states: torch.Tensor,
+        fill_ids: Optional[List[int]],
+    ) -> None:
+        """Stash a loaded snapshot in the pending-restore registry.
+
+        Indexed by both rid and conversation_id so a follow-up request can hit
+        on either key. Bounded by PENDING_RESTORE_REGISTRY_MAX with LRU eviction
+        of the oldest entry when capacity is exceeded.
+        """
+        if getattr(self, "pending_restore_registry", None) is None:
+            return
+
+        entry = PendingRestoreEntry(
+            conv_states=conv_states,
+            temporal_states=temporal_states,
+            fill_ids=list(fill_ids) if fill_ids is not None else None,
+            conversation_id=conversation_id,
+            timestamp=time.time(),
+        )
+
+        keys = [rid]
+        if conversation_id and conversation_id != rid:
+            keys.append(conversation_id)
+
+        for key in keys:
+            if key in self.pending_restore_registry:
+                self.pending_restore_registry.pop(key)
+            self.pending_restore_registry[key] = entry
+
+        while len(self.pending_restore_registry) > PENDING_RESTORE_REGISTRY_MAX:
+            evicted_key, _ = self.pending_restore_registry.popitem(last=False)
+            logger.debug(
+                "pending-restore registry: evicted oldest entry key=%s "
+                "(capacity=%d)",
+                evicted_key,
+                PENDING_RESTORE_REGISTRY_MAX,
+            )
+
+    def _maybe_hydrate_from_pending_restore(self, req) -> bool:
+        """Attach restored Mamba state to ``req`` if its rid (or conversation_id)
+        has a staged entry in the pending-restore registry.
+
+        Allocates a fresh mamba_pool slot, injects the staged state into it,
+        and assigns ``req.mamba_pool_idx``. The new turn's tokens stay in
+        ``req.origin_input_ids`` unmodified — the SSM state in the pool slot
+        carries the prior conversation history, so prefill processes only the
+        new tokens on top of injected state.
+
+        Returns True when state was attached, False otherwise.
+        """
+        registry = getattr(self, "pending_restore_registry", None)
+        if not registry:
+            return False
+        if getattr(req, "mamba_pool_idx", None) is not None:
+            return False
+
+        rid = req.rid
+        conv_id = getattr(req, "conversation_id", None)
+
+        entry = registry.get(rid)
+        matched_key = rid if entry is not None else None
+        if entry is None and conv_id and conv_id != rid:
+            entry = registry.get(conv_id)
+            matched_key = conv_id if entry is not None else None
+        if entry is None:
+            return False
+
+        mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
+        if mamba_pool is None:
+            logger.warning(
+                "pending-restore registry hit for rid=%s but mamba_pool "
+                "unavailable; skipping hydration",
+                rid,
+            )
+            return False
+
+        new_pool_idx = mamba_pool.alloc(1)
+        if new_pool_idx is None:
+            logger.warning(
+                "pending-restore registry hit for rid=%s but no free Mamba "
+                "pool slots; skipping hydration",
+                rid,
+            )
+            return False
+
+        new_pool_idx_0d = new_pool_idx[0]
+        new_pool_idx_scalar = new_pool_idx_0d.item()
+
+        try:
+            self.snapshot_manager.inject_state_to_pool(
+                entry.conv_states,
+                entry.temporal_states,
+                mamba_pool,
+                new_pool_idx_scalar,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to inject pending-restore state for rid=%s: %s",
+                rid,
+                e,
+                exc_info=True,
+            )
+            try:
+                mamba_pool.free(new_pool_idx)
+            except Exception as cleanup_error:
+                logger.error(
+                    "Failed to free mamba pool slot during pending-restore "
+                    "hydration cleanup: %s",
+                    cleanup_error,
+                )
+            return False
+
+        req.mamba_pool_idx = new_pool_idx_0d
+        if not getattr(req, "conversation_id", None):
+            req.conversation_id = entry.conversation_id
+
+        # Touch the registry entry to mark it most-recently-used. Entries stay
+        # after consumption so back-to-back requests with the same rid reuse
+        # the staged state without requiring another /restore_snapshot call.
+        if matched_key is not None and matched_key in registry:
+            registry.move_to_end(matched_key)
+        if (
+            entry.conversation_id
+            and entry.conversation_id != matched_key
+            and entry.conversation_id in registry
+        ):
+            registry.move_to_end(entry.conversation_id)
+
+        # Reset health baselines so anomaly detection treats restored state
+        # as a fresh starting point rather than a divergence from prior live
+        # state.
+        if self.state_health_monitor is not None:
+            self.state_health_monitor.reset_baseline(entry.conversation_id)
+            self._health_check_counter[entry.conversation_id] = 0
+
+        logger.info(
+            "pending-restore registry hit: hydrated rid=%s "
+            "(matched_key=%s, conv_id=%s, mamba_pool_idx=%d)",
+            rid,
+            matched_key,
+            entry.conversation_id,
+            new_pool_idx_scalar,
+        )
+        return True
 
     def handle_save_snapshot(self, recv_req):
         """Handle a manual snapshot save request from the Lang API.
@@ -1836,20 +2055,74 @@ class Scheduler(
             # Find the request by rid
             req = self._find_request_by_rid(recv_req.rid)
             if req is None:
-                # Request has already completed — check if snapshot exists for this rid.
-                # If it does, the state is available for future requests; report success.
-                snapshot_exists = (
-                    self.tier_manager is not None
-                    and self.tier_manager.host_pool.has_state(effective_conv_id)
-                ) or bool(self.snapshot_manager.get_latest_snapshot(effective_conv_id))
-                if snapshot_exists:
+                # Request has already completed. Load the snapshot and stage it
+                # in the pending-restore registry so the next incoming request
+                # with this rid (or conversation_id) hydrates from it.
+                loaded = self._load_snapshot_for_pending_restore(
+                    effective_conv_id, recv_req.turn_number, recv_req.branch_name
+                )
+                if loaded is None:
                     return RestoreSnapshotReqOutput(
-                        success=True,
-                        message=f"Snapshot state available for future requests (rid={recv_req.rid})",
-                        token_count=None,
+                        success=False,
+                        message=(
+                            f"Snapshot not found: conversation={effective_conv_id}, "
+                            f"turn={recv_req.turn_number}, "
+                            f"branch={recv_req.branch_name}"
+                        ),
                     )
+                conv_states_p, temporal_states_p, metadata_p = loaded
+
+                # Model compatibility check — same guard as the live-req path.
+                running_model = getattr(self.server_args, "model_path", None)
+                snap_model = (
+                    metadata_p.get("model_name")
+                    if isinstance(metadata_p, dict)
+                    else getattr(metadata_p, "model_name", None)
+                )
+                if running_model and snap_model and snap_model != running_model:
+                    return RestoreSnapshotReqOutput(
+                        success=False,
+                        message=(
+                            f"Model mismatch: snapshot from "
+                            f"'{snap_model}', server running '{running_model}'"
+                        ),
+                    )
+
+                fill_ids_p = (
+                    metadata_p.get("fill_ids")
+                    if isinstance(metadata_p, dict)
+                    else getattr(metadata_p, "fill_ids", None)
+                )
+                token_count_p = (
+                    metadata_p.get("token_count")
+                    if isinstance(metadata_p, dict)
+                    else getattr(metadata_p, "token_count", None)
+                )
+
+                self._stage_pending_restore(
+                    rid=recv_req.rid,
+                    conversation_id=effective_conv_id,
+                    conv_states=conv_states_p,
+                    temporal_states=temporal_states_p,
+                    fill_ids=fill_ids_p,
+                )
+
+                logger.info(
+                    "Snapshot staged for pending restore: "
+                    "conversation=%s, rid=%s, token_count=%s",
+                    effective_conv_id,
+                    recv_req.rid,
+                    token_count_p,
+                )
+
                 return RestoreSnapshotReqOutput(
-                    success=False, message=f"Request not found: {recv_req.rid}"
+                    success=True,
+                    message=(
+                        f"Snapshot staged for next request "
+                        f"(rid={recv_req.rid}, conversation_id={effective_conv_id})"
+                    ),
+                    token_count=token_count_p,
+                    rid=recv_req.rid,
                 )
 
             # Check that request is idle (not currently running)
@@ -3276,6 +3549,14 @@ class Scheduler(
                 self.init_req_max_new_tokens(req)
                 self._add_request_to_queue(req)
                 return
+
+        # --- BEGIN ENGRAM: pending-restore registry hydration ---
+        # If /restore_snapshot was called for this rid (or conversation_id) and
+        # the originating Req had already finished, the loaded state was staged
+        # in the pending-restore registry. Hydrate this fresh Req from that
+        # entry so the model sees the restored Mamba state at prefill.
+        self._maybe_hydrate_from_pending_restore(req)
+        # --- END ENGRAM ---
 
         # initialize before returning
         self.init_req_max_new_tokens(req)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2302,6 +2302,26 @@ class Scheduler(
             req.origin_input_ids = metadata.fill_ids  # keep as list for downstream code
             logger.info(f"Synced fill_ids after restore, len={len(metadata.fill_ids)}")
 
+            # Conv_id conflict resolution: state is authoritative for the conversation
+            # it belongs to. If req.conversation_id differs from effective_conv_id,
+            # log a warning and overwrite (mirrors Finding 5 fix in
+            # _maybe_hydrate_from_pending_restore for the symmetric pending path).
+            if (
+                getattr(req, "conversation_id", None)
+                and req.conversation_id != effective_conv_id
+            ):
+                logger.warning(
+                    "Live restore: req.conversation_id=%s differs from effective_conv_id=%s "
+                    "for rid=%s; overwriting req.conversation_id with effective_conv_id "
+                    "(state is authoritative for the conversation it belongs to)",
+                    req.conversation_id,
+                    effective_conv_id,
+                    recv_req.rid,
+                )
+                req.conversation_id = effective_conv_id
+            elif not getattr(req, "conversation_id", None):
+                req.conversation_id = effective_conv_id
+
             # Reset health baselines after restore to avoid false anomalies
             if self.state_health_monitor is not None:
                 self.state_health_monitor.reset_baseline(effective_conv_id)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1528,6 +1528,31 @@ class Scheduler(
                 PENDING_RESTORE_REGISTRY_MAX,
             )
 
+    def _clear_pending_restore(self, rid: str, conversation_id: Optional[str]) -> None:
+        """Remove any pending-restore entry for (rid, conversation_id).
+
+        Called after a live /restore_snapshot succeeds (path-B-with-live-req) to
+        prevent _maybe_hydrate_from_pending_restore from later resurrecting stale
+        state for a follow-up request with the same rid or conv_id.
+        """
+        registry = getattr(self, "pending_restore_registry", None)
+        aliases = getattr(self, "pending_restore_aliases", None)
+        if not registry:
+            return
+
+        # Resolve canonical via rid first, then via conversation_id alias
+        canonical = rid if rid in registry else None
+        if canonical is None and conversation_id and aliases:
+            canonical = aliases.get(conversation_id)
+        if canonical is None or canonical not in registry:
+            return
+
+        del registry[canonical]
+        if aliases:
+            for alias_key, target in list(aliases.items()):
+                if target == canonical:
+                    del aliases[alias_key]
+
     def _maybe_hydrate_from_pending_restore(self, req) -> Optional[bool]:
         """Attach restored Mamba state to ``req`` if its rid (or conversation_id)
         has a staged entry in the pending-restore registry.
@@ -1558,6 +1583,7 @@ class Scheduler(
 
         # Lookup: canonical first, then resolve via alias
         canonical = rid if rid in registry else None
+        matched_via_rid = canonical is not None
         if canonical is None and conv_id and conv_id != rid:
             canonical = self.pending_restore_aliases.get(conv_id)
         if canonical is None or canonical not in registry:
@@ -1611,7 +1637,27 @@ class Scheduler(
             return False
 
         req.mamba_pool_idx = new_pool_idx_0d
-        if not getattr(req, "conversation_id", None):
+        # Assign or reconcile conversation_id from the hydrated entry.
+        # When the entry was matched via rid (not alias) and the request
+        # already carries a different conversation_id, the entry's is
+        # authoritative — state belongs to the conversation stored with it,
+        # not to whatever the request happened to carry.
+        if (
+            matched_via_rid
+            and getattr(req, "conversation_id", None)
+            and req.conversation_id != entry.conversation_id
+        ):
+            logger.warning(
+                "pending-restore hydration: req.conversation_id=%s differs from "
+                "entry.conversation_id=%s for rid=%s; overwriting "
+                "req.conversation_id with entry's (state is authoritative for "
+                "the conversation it belongs to)",
+                req.conversation_id,
+                entry.conversation_id,
+                rid,
+            )
+            req.conversation_id = entry.conversation_id
+        elif not getattr(req, "conversation_id", None):
             req.conversation_id = entry.conversation_id
 
         # Touch the canonical entry to mark it most-recently-used.
@@ -2244,6 +2290,10 @@ class Scheduler(
             self.snapshot_manager.inject_state_to_pool(
                 conv_states, temporal_states, mamba_pool, req.mamba_pool_idx
             )
+
+            # Clear any pending-restore entry so a follow-up request with the
+            # same rid doesn't hydrate from the now-stale staged entry.
+            self._clear_pending_restore(recv_req.rid, effective_conv_id)
 
             # Sync fill_ids from metadata to request
             req.fill_ids = torch.tensor(

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -6,6 +6,10 @@ exercise the producer (_stage_pending_restore), capacity bound + LRU eviction,
 key aliasing (rid + conversation_id), and the consumer hydration semantics
 (_maybe_hydrate_from_pending_restore) including pool allocation and Req-state
 mutation.
+
+The registry uses a canonical OrderedDict (rid → entry) plus a separate alias
+map (conv_id → canonical rid). Tests validate that replacement, eviction, and
+lookup are atomic across all keys mapping to a given logical entry.
 """
 
 import os
@@ -60,10 +64,18 @@ class _FakeSnapshotManager:
         )
 
 
+class _FailingSnapshotManager:
+    """Raises RuntimeError on every inject_state_to_pool call."""
+
+    def inject_state_to_pool(self, conv_states, temporal_states, mamba_pool, idx):
+        raise RuntimeError("inject_state_to_pool failure")
+
+
 def _build_scheduler():
     """Build a bare Scheduler with only the fields the registry methods touch."""
     scheduler = Scheduler.__new__(Scheduler)
     scheduler.pending_restore_registry = OrderedDict()
+    scheduler.pending_restore_aliases = {}
     scheduler.snapshot_manager = _FakeSnapshotManager()
     scheduler.state_health_monitor = None
     scheduler._health_check_counter = {}
@@ -85,7 +97,13 @@ def _make_req(rid: str, conversation_id=None, mamba_pool_idx=None):
     )
 
 
+# ---------------------------------------------------------------------------
+# Producer tests — _stage_pending_restore
+# ---------------------------------------------------------------------------
+
+
 def test_stage_indexes_by_rid_and_conversation_id():
+    """Canonical entry keyed by rid; conversation_id stored as alias."""
     scheduler, _ = _build_scheduler()
     conv_states, temporal_states = _make_state()
 
@@ -97,12 +115,11 @@ def test_stage_indexes_by_rid_and_conversation_id():
         fill_ids=[1, 2, 3],
     )
 
+    # Canonical entry is in the registry, not under the alias key
     assert "rid-A" in scheduler.pending_restore_registry
-    assert "conv-1" in scheduler.pending_restore_registry
-    assert (
-        scheduler.pending_restore_registry["rid-A"]
-        is scheduler.pending_restore_registry["conv-1"]
-    )
+    assert "conv-1" not in scheduler.pending_restore_registry
+    # Alias maps conv_id → canonical rid
+    assert scheduler.pending_restore_aliases["conv-1"] == "rid-A"
     assert scheduler.pending_restore_registry["rid-A"].fill_ids == [1, 2, 3]
 
 
@@ -119,6 +136,7 @@ def test_stage_when_rid_equals_conversation_id_uses_single_key():
     )
 
     assert list(scheduler.pending_restore_registry.keys()) == ["same-id"]
+    assert scheduler.pending_restore_aliases == {}
 
 
 def test_stage_evicts_oldest_when_over_capacity():
@@ -169,18 +187,129 @@ def test_stage_replaces_existing_entry_for_same_rid():
     assert torch.equal(entry.conv_states[0], conv_states_new[0])
 
 
+# ---------------------------------------------------------------------------
+# Finding 1 tests — multi-key replacement, cross-rid replacement, eviction
+# ---------------------------------------------------------------------------
+
+
+def test_multi_key_replacement_same_rid_different_conv():
+    """Stage rid-A/conv-1 then rid-A/conv-2: old alias is gone, new entry
+    reachable via both rid-A and conv-2."""
+    scheduler, _ = _build_scheduler()
+    cs1, ts1 = _make_state(1.0)
+    cs2, ts2 = _make_state(2.0)
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs1,
+        temporal_states=ts1,
+        fill_ids=[1],
+    )
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-2",
+        conv_states=cs2,
+        temporal_states=ts2,
+        fill_ids=[2],
+    )
+
+    # Old alias conv-1 must be gone
+    assert "conv-1" not in scheduler.pending_restore_aliases
+    assert "conv-1" not in scheduler.pending_restore_registry
+    # New alias conv-2 points to canonical rid-A
+    assert scheduler.pending_restore_aliases["conv-2"] == "rid-A"
+    # Canonical entry holds the new data
+    assert scheduler.pending_restore_registry["rid-A"].fill_ids == [2]
+    assert torch.equal(
+        scheduler.pending_restore_registry["rid-A"].conv_states[0], cs2[0]
+    )
+
+
+def test_cross_rid_same_conv_replacement():
+    """Stage rid-A/conv-1 then rid-B/conv-1: rid-A removed, rid-B and conv-1
+    both resolve to entry-2."""
+    scheduler, _ = _build_scheduler()
+    cs1, ts1 = _make_state(1.0)
+    cs2, ts2 = _make_state(2.0)
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs1,
+        temporal_states=ts1,
+        fill_ids=[1],
+    )
+    scheduler._stage_pending_restore(
+        rid="rid-B",
+        conversation_id="conv-1",
+        conv_states=cs2,
+        temporal_states=ts2,
+        fill_ids=[2],
+    )
+
+    # rid-A should be fully evicted (conv-1 collided as canonical with another entry)
+    assert "rid-A" not in scheduler.pending_restore_registry
+    # rid-B is the new canonical
+    assert "rid-B" in scheduler.pending_restore_registry
+    assert scheduler.pending_restore_registry["rid-B"].fill_ids == [2]
+    # conv-1 alias points to rid-B
+    assert scheduler.pending_restore_aliases.get("conv-1") == "rid-B"
+
+
+def test_multi_key_eviction_with_distinct_keys():
+    """Stage MAX+5 pairs all with conv != rid.
+    Assert canonical size == MAX and alias map contains only surviving aliases."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+    n = PENDING_RESTORE_REGISTRY_MAX + 5
+
+    for i in range(n):
+        scheduler._stage_pending_restore(
+            rid=f"rid-{i}",
+            conversation_id=f"conv-{i}",
+            conv_states=cs,
+            temporal_states=ts,
+            fill_ids=[i],
+        )
+
+    # Canonical size bounded to MAX
+    assert len(scheduler.pending_restore_registry) == PENDING_RESTORE_REGISTRY_MAX
+
+    # Oldest 5 canonicals evicted
+    for i in range(5):
+        assert f"rid-{i}" not in scheduler.pending_restore_registry
+        # Their aliases should also be gone
+        assert f"conv-{i}" not in scheduler.pending_restore_aliases
+
+    # Every alias in the map points to a surviving canonical
+    for alias, canonical in scheduler.pending_restore_aliases.items():
+        assert canonical in scheduler.pending_restore_registry
+
+    # Latest entry is present in both structures
+    assert f"rid-{n - 1}" in scheduler.pending_restore_registry
+    assert scheduler.pending_restore_aliases[f"conv-{n - 1}"] == f"rid-{n - 1}"
+
+
+# ---------------------------------------------------------------------------
+# Consumer tests — _maybe_hydrate_from_pending_restore
+# ---------------------------------------------------------------------------
+
+
 def test_hydrate_misses_when_registry_empty():
+    """Tri-state: true miss returns None."""
     scheduler, _ = _build_scheduler()
     req = _make_req("rid-missing")
 
     hit = scheduler._maybe_hydrate_from_pending_restore(req)
 
-    assert hit is False
+    assert hit is None
     assert req.mamba_pool_idx is None
     assert scheduler.snapshot_manager.injected == []
 
 
 def test_hydrate_hits_by_rid_and_attaches_pool_slot():
+    """Tri-state: successful hydration returns True."""
     scheduler, mamba_pool = _build_scheduler()
     conv_states, temporal_states = _make_state()
     scheduler._stage_pending_restore(
@@ -204,6 +333,7 @@ def test_hydrate_hits_by_rid_and_attaches_pool_slot():
 
 
 def test_hydrate_falls_back_to_conversation_id_when_rid_misses():
+    """Tri-state: alias resolution finds the canonical entry, returns True."""
     scheduler, _ = _build_scheduler()
     conv_states, temporal_states = _make_state()
     scheduler._stage_pending_restore(
@@ -213,7 +343,7 @@ def test_hydrate_falls_back_to_conversation_id_when_rid_misses():
         temporal_states=temporal_states,
         fill_ids=[1],
     )
-    # Different rid but same conversation_id
+    # Different rid but same conversation_id — resolves via alias
     req = _make_req("rid-different", conversation_id="conv-1")
 
     hit = scheduler._maybe_hydrate_from_pending_restore(req)
@@ -223,6 +353,7 @@ def test_hydrate_falls_back_to_conversation_id_when_rid_misses():
 
 
 def test_hydrate_skips_when_req_already_has_pool_slot():
+    """Tri-state: already-hydrated request returns None (true miss)."""
     scheduler, _ = _build_scheduler()
     conv_states, temporal_states = _make_state()
     scheduler._stage_pending_restore(
@@ -237,12 +368,13 @@ def test_hydrate_skips_when_req_already_has_pool_slot():
 
     hit = scheduler._maybe_hydrate_from_pending_restore(req)
 
-    assert hit is False
+    assert hit is None
     assert req.mamba_pool_idx is existing_idx
     assert scheduler.snapshot_manager.injected == []
 
 
 def test_hydrate_returns_false_when_pool_exhausted():
+    """Tri-state: staged entry, pool full, returns False, no pool slot leaked."""
     scheduler, mamba_pool = _build_scheduler()
     mamba_pool._next = mamba_pool._capacity  # full
     conv_states, temporal_states = _make_state()
@@ -262,6 +394,7 @@ def test_hydrate_returns_false_when_pool_exhausted():
 
 
 def test_hydrate_consumption_keeps_entry_for_back_to_back_requests():
+    """Tri-state: back-to-back hydration returns True each time, fresh slots."""
     scheduler, _ = _build_scheduler()
     conv_states, temporal_states = _make_state()
     scheduler._stage_pending_restore(
@@ -280,6 +413,90 @@ def test_hydrate_consumption_keeps_entry_for_back_to_back_requests():
     assert scheduler._maybe_hydrate_from_pending_restore(req2) is True
     assert req1.mamba_pool_idx.item() != req2.mamba_pool_idx.item()
     assert len(scheduler.snapshot_manager.injected) == 2
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 tests — tri-state hydration (true miss, success, exhausted, error)
+# ---------------------------------------------------------------------------
+
+
+def test_tri_state_true_miss_empty_registry():
+    """Empty registry returns None (true miss)."""
+    scheduler, _ = _build_scheduler()
+    req = _make_req("rid-absent")
+
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is None
+
+
+def test_tri_state_success_returns_true():
+    """Staged entry with available pool returns True and allocates slot."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+    req = _make_req("rid-A")
+
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is True
+    assert req.mamba_pool_idx is not None
+    assert len(scheduler.snapshot_manager.injected) == 1
+
+
+def test_tri_state_pool_exhausted_returns_false_no_leak():
+    """Pool full: returns False, no slot was allocated (so nothing to leak)."""
+    scheduler, mamba_pool = _build_scheduler()
+    mamba_pool._next = mamba_pool._capacity  # pool already full
+    cs, ts = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="rid-A",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+    req = _make_req("rid-A")
+
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is False
+    assert req.mamba_pool_idx is None
+    # alloc() returned None, so no inject was attempted
+    assert scheduler.snapshot_manager.injected == []
+
+
+def test_tri_state_inject_error_returns_false_and_frees_slot():
+    """inject_state_to_pool raises: returns False, allocated pool slot freed."""
+    scheduler, mamba_pool = _build_scheduler()
+    scheduler.snapshot_manager = _FailingSnapshotManager()
+    cs, ts = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="rid-A",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+    req = _make_req("rid-A")
+
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is False
+    assert req.mamba_pool_idx is None
+    # The allocated slot (idx 0) should have been freed during cleanup
+    assert len(mamba_pool._freed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dataclass sanity
+# ---------------------------------------------------------------------------
 
 
 def test_pending_restore_entry_dataclass_fields():

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -1,0 +1,296 @@
+"""Unit tests for the pending-restore registry on the Scheduler.
+
+The registry stages loaded snapshot state for a future incoming request when
+/restore_snapshot is called after the originating Req has finished. Tests
+exercise the producer (_stage_pending_restore), capacity bound + LRU eviction,
+key aliasing (rid + conversation_id), and the consumer hydration semantics
+(_maybe_hydrate_from_pending_restore) including pool allocation and Req-state
+mutation.
+"""
+
+import os
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import torch
+
+os.environ.setdefault("HOME", "/tmp")
+os.environ.setdefault("XDG_CACHE_HOME", "/tmp")
+
+from sglang.srt.managers.scheduler import (
+    PENDING_RESTORE_REGISTRY_MAX,
+    PendingRestoreEntry,
+    Scheduler,
+)
+
+
+class _FakeMambaPool:
+    """Minimal mamba_pool stub: hands out monotonic 0-dim tensor indices."""
+
+    def __init__(self, capacity: int = 8):
+        self._next = 0
+        self._capacity = capacity
+        self._freed = []
+
+    def alloc(self, n: int):
+        if self._next >= self._capacity:
+            return None
+        out = torch.tensor([self._next], dtype=torch.int32)
+        self._next += n
+        return out
+
+    def free(self, idx):
+        self._freed.append(idx)
+
+
+class _FakeSnapshotManager:
+    """Records inject_state_to_pool calls so tests can assert on them."""
+
+    def __init__(self):
+        self.injected = []
+
+    def inject_state_to_pool(self, conv_states, temporal_states, mamba_pool, idx):
+        self.injected.append(
+            {
+                "conv_states": conv_states,
+                "temporal_states": temporal_states,
+                "mamba_pool": mamba_pool,
+                "idx": idx,
+            }
+        )
+
+
+def _build_scheduler():
+    """Build a bare Scheduler with only the fields the registry methods touch."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.pending_restore_registry = OrderedDict()
+    scheduler.snapshot_manager = _FakeSnapshotManager()
+    scheduler.state_health_monitor = None
+    scheduler._health_check_counter = {}
+    mamba_pool = _FakeMambaPool()
+    scheduler.req_to_token_pool = SimpleNamespace(mamba_pool=mamba_pool)
+    return scheduler, mamba_pool
+
+
+def _make_state(value: float = 1.0):
+    return [torch.full((1, 2), value)], torch.full((1, 2), value + 1)
+
+
+def _make_req(rid: str, conversation_id=None, mamba_pool_idx=None):
+    return SimpleNamespace(
+        rid=rid,
+        conversation_id=conversation_id,
+        mamba_pool_idx=mamba_pool_idx,
+        origin_input_ids=[10, 20, 30],
+    )
+
+
+def test_stage_indexes_by_rid_and_conversation_id():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1, 2, 3],
+    )
+
+    assert "rid-A" in scheduler.pending_restore_registry
+    assert "conv-1" in scheduler.pending_restore_registry
+    assert (
+        scheduler.pending_restore_registry["rid-A"]
+        is scheduler.pending_restore_registry["conv-1"]
+    )
+    assert scheduler.pending_restore_registry["rid-A"].fill_ids == [1, 2, 3]
+
+
+def test_stage_when_rid_equals_conversation_id_uses_single_key():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="same-id",
+        conversation_id="same-id",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=None,
+    )
+
+    assert list(scheduler.pending_restore_registry.keys()) == ["same-id"]
+
+
+def test_stage_evicts_oldest_when_over_capacity():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+
+    for i in range(PENDING_RESTORE_REGISTRY_MAX + 5):
+        scheduler._stage_pending_restore(
+            rid=f"rid-{i}",
+            conversation_id=f"rid-{i}",
+            conv_states=conv_states,
+            temporal_states=temporal_states,
+            fill_ids=[i],
+        )
+
+    assert len(scheduler.pending_restore_registry) == PENDING_RESTORE_REGISTRY_MAX
+    # Oldest five should have been evicted
+    for i in range(5):
+        assert f"rid-{i}" not in scheduler.pending_restore_registry
+    # Newest entry should be present
+    assert (
+        f"rid-{PENDING_RESTORE_REGISTRY_MAX + 4}" in scheduler.pending_restore_registry
+    )
+
+
+def test_stage_replaces_existing_entry_for_same_rid():
+    scheduler, _ = _build_scheduler()
+    conv_states_old, temporal_states_old = _make_state(1.0)
+    conv_states_new, temporal_states_new = _make_state(2.0)
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=conv_states_old,
+        temporal_states=temporal_states_old,
+        fill_ids=[1],
+    )
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=conv_states_new,
+        temporal_states=temporal_states_new,
+        fill_ids=[2],
+    )
+
+    entry = scheduler.pending_restore_registry["rid-A"]
+    assert entry.fill_ids == [2]
+    assert torch.equal(entry.conv_states[0], conv_states_new[0])
+
+
+def test_hydrate_misses_when_registry_empty():
+    scheduler, _ = _build_scheduler()
+    req = _make_req("rid-missing")
+
+    hit = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert hit is False
+    assert req.mamba_pool_idx is None
+    assert scheduler.snapshot_manager.injected == []
+
+
+def test_hydrate_hits_by_rid_and_attaches_pool_slot():
+    scheduler, mamba_pool = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1, 2, 3],
+    )
+    req = _make_req("rid-A", conversation_id="conv-1")
+
+    hit = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert hit is True
+    assert req.mamba_pool_idx is not None
+    assert req.mamba_pool_idx.item() == 0
+    assert len(scheduler.snapshot_manager.injected) == 1
+    assert scheduler.snapshot_manager.injected[0]["idx"] == 0
+    # Origin input ids are NOT modified — SSM state carries history.
+    assert req.origin_input_ids == [10, 20, 30]
+
+
+def test_hydrate_falls_back_to_conversation_id_when_rid_misses():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-original",
+        conversation_id="conv-1",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1],
+    )
+    # Different rid but same conversation_id
+    req = _make_req("rid-different", conversation_id="conv-1")
+
+    hit = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert hit is True
+    assert req.mamba_pool_idx is not None
+
+
+def test_hydrate_skips_when_req_already_has_pool_slot():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="rid-A",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1],
+    )
+    existing_idx = torch.tensor(99, dtype=torch.int32)
+    req = _make_req("rid-A", mamba_pool_idx=existing_idx)
+
+    hit = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert hit is False
+    assert req.mamba_pool_idx is existing_idx
+    assert scheduler.snapshot_manager.injected == []
+
+
+def test_hydrate_returns_false_when_pool_exhausted():
+    scheduler, mamba_pool = _build_scheduler()
+    mamba_pool._next = mamba_pool._capacity  # full
+    conv_states, temporal_states = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="rid-A",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1],
+    )
+    req = _make_req("rid-A")
+
+    hit = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert hit is False
+    assert req.mamba_pool_idx is None
+
+
+def test_hydrate_consumption_keeps_entry_for_back_to_back_requests():
+    scheduler, _ = _build_scheduler()
+    conv_states, temporal_states = _make_state()
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="rid-A",
+        conv_states=conv_states,
+        temporal_states=temporal_states,
+        fill_ids=[1],
+    )
+
+    req1 = _make_req("rid-A")
+    assert scheduler._maybe_hydrate_from_pending_restore(req1) is True
+    assert "rid-A" in scheduler.pending_restore_registry
+
+    req2 = _make_req("rid-A")
+    assert scheduler._maybe_hydrate_from_pending_restore(req2) is True
+    assert req1.mamba_pool_idx.item() != req2.mamba_pool_idx.item()
+    assert len(scheduler.snapshot_manager.injected) == 2
+
+
+def test_pending_restore_entry_dataclass_fields():
+    """Sanity check that the dataclass exposes the expected attributes."""
+    entry = PendingRestoreEntry(
+        conv_states=[torch.zeros(1)],
+        temporal_states=torch.zeros(1),
+        fill_ids=[1, 2],
+        conversation_id="conv-x",
+        timestamp=123.0,
+    )
+    assert entry.fill_ids == [1, 2]
+    assert entry.conversation_id == "conv-x"
+    assert entry.timestamp == 123.0

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -612,6 +612,119 @@ def test_tri_state_inject_error_returns_false_and_frees_slot():
 
 
 # ---------------------------------------------------------------------------
+# Finding 4 tests — _clear_pending_restore
+# ---------------------------------------------------------------------------
+
+
+def test_clear_pending_restore_removes_canonical_and_aliases():
+    """Stage rid-A/conv-1, clear via rid, assert registry and aliases are empty."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+
+    scheduler._clear_pending_restore(rid="rid-A", conversation_id="conv-1")
+
+    assert "rid-A" not in scheduler.pending_restore_registry
+    assert "conv-1" not in scheduler.pending_restore_aliases
+    assert len(scheduler.pending_restore_registry) == 0
+    assert len(scheduler.pending_restore_aliases) == 0
+
+
+def test_clear_pending_restore_resolves_via_alias():
+    """Stage rid-A/conv-1, clear via unmatched rid + alias conv-1; entry gone."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+
+    scheduler._clear_pending_restore(rid="rid-other", conversation_id="conv-1")
+
+    assert "rid-A" not in scheduler.pending_restore_registry
+    assert "conv-1" not in scheduler.pending_restore_aliases
+    assert len(scheduler.pending_restore_registry) == 0
+
+
+def test_clear_pending_restore_no_op_on_miss():
+    """Empty registry: call raises no exception and leaves state unchanged."""
+    scheduler, _ = _build_scheduler()
+
+    scheduler._clear_pending_restore("rid-absent", "conv-absent")
+
+    assert len(scheduler.pending_restore_registry) == 0
+    assert len(scheduler.pending_restore_aliases) == 0
+
+
+# ---------------------------------------------------------------------------
+# Finding 5 tests — conv_id conflict resolution during hydration
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_warns_and_overwrites_on_conv_mismatch(caplog):
+    """stage rid-A/conv-X, hydrate with req.conversation_id=conv-Y.
+    Warning logged, req.conversation_id overwritten to conv-X, hydration ok."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-X",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+
+    req = _make_req("rid-A", conversation_id="conv-Y")
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is True
+    assert req.conversation_id == "conv-X"
+    # Warning was emitted for the conflict
+    assert any(
+        "differs from" in record.message and "conv-Y" in record.message
+        for record in caplog.records
+    )
+
+
+def test_hydrate_alias_path_does_not_warn_on_conv_match():
+    """stage rid-A/conv-1, hydrate with different rid + matching conv_id=conv-1.
+    No warning needed — alias path by construction matches the correct entry."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[1],
+    )
+
+    req = _make_req("rid-different", conversation_id="conv-1")
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+
+    assert result is True
+    assert req.conversation_id == "conv-1"
+    assert req.mamba_pool_idx is not None
+
+
+# ---------------------------------------------------------------------------
 # Dataclass sanity
 # ---------------------------------------------------------------------------
 

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -292,6 +292,125 @@ def test_multi_key_eviction_with_distinct_keys():
 
 
 # ---------------------------------------------------------------------------
+# Finding 3 + Case B tests — alias remap evicts old canonical
+# ---------------------------------------------------------------------------
+
+
+def test_stage_evicts_old_canonical_when_alias_remapped():
+    """Finding 3: staging rid-B/conv-1 after rid-A/conv-1 evicts rid-A
+    and all its aliases. The old canonical must not remain reachable."""
+    scheduler, _ = _build_scheduler()
+    cs1, ts1 = _make_state(1.0)
+    cs2, ts2 = _make_state(2.0)
+
+    scheduler._stage_pending_restore(
+        rid="rid-A",
+        conversation_id="conv-1",
+        conv_states=cs1,
+        temporal_states=ts1,
+        fill_ids=[1],
+    )
+    scheduler._stage_pending_restore(
+        rid="rid-B",
+        conversation_id="conv-1",
+        conv_states=cs2,
+        temporal_states=ts2,
+        fill_ids=[2],
+    )
+
+    # Old canonical rid-A must be gone — alias was remapped
+    assert "rid-A" not in scheduler.pending_restore_registry
+    # No leftover alias for rid-A
+    assert "rid-A" not in scheduler.pending_restore_aliases
+    # conv-1 alias now points at rid-B
+    assert scheduler.pending_restore_aliases.get("conv-1") == "rid-B"
+    # Only one canonical entry remains
+    assert len(scheduler.pending_restore_registry) == 1
+    assert scheduler.pending_restore_registry["rid-B"].fill_ids == [2]
+
+
+def test_stage_evicts_old_canonical_when_rid_was_previously_alias():
+    """Case B: staging rid-R/conv-X after rid-P/conv-R evicts rid-P.
+    rid-R was previously an alias for rid-P; after staging as canonical
+    there must be no orphan alias rid-R→rid-P remaining."""
+    scheduler, _ = _build_scheduler()
+    cs1, ts1 = _make_state(1.0)
+    cs2, ts2 = _make_state(2.0)
+
+    # First: rid-P is canonical, conv-R alias → rid-P (so rid-R is an alias)
+    scheduler._stage_pending_restore(
+        rid="rid-P",
+        conversation_id="conv-R",
+        conv_states=cs1,
+        temporal_states=ts1,
+        fill_ids=[1],
+    )
+    # Second: rid-R is now the new canonical with its own alias conv-X
+    scheduler._stage_pending_restore(
+        rid="rid-R",
+        conversation_id="conv-X",
+        conv_states=cs2,
+        temporal_states=ts2,
+        fill_ids=[2],
+    )
+
+    # Old canonical rid-P must be gone (rid-R was its alias, now promoted)
+    assert "rid-P" not in scheduler.pending_restore_registry
+    # No orphan alias rid-R→rid-P remains
+    assert "rid-R" not in scheduler.pending_restore_aliases
+    # The old alias conv-R from the rid-P entry must be gone too
+    assert "conv-R" not in scheduler.pending_restore_aliases
+    # Only rid-R canonical exists
+    assert len(scheduler.pending_restore_registry) == 1
+    assert scheduler.pending_restore_registry["rid-R"].fill_ids == [2]
+    # conv-X alias points to rid-R
+    assert scheduler.pending_restore_aliases.get("conv-X") == "rid-R"
+
+
+def test_orphan_alias_does_not_resurrect_on_eviction():
+    """Evict an entry whose alias was previously remapped.
+    Assert no stale alias resurrects the old canonical on subsequent hydration."""
+    scheduler, _ = _build_scheduler()
+    cs, ts = _make_state()
+
+    # Fill registry with MAX entries, each with distinct rid and conv_id
+    for i in range(PENDING_RESTORE_REGISTRY_MAX):
+        scheduler._stage_pending_restore(
+            rid=f"rid-{i}",
+            conversation_id=f"conv-{i}",
+            conv_states=cs,
+            temporal_states=ts,
+            fill_ids=[i],
+        )
+
+    # Remap an existing alias → new canonical (Finding 3 scenario)
+    # rid-0/conv-0 exists; stage rid-NEW/conv-0 to force remap
+    scheduler._stage_pending_restore(
+        rid="rid-NEW",
+        conversation_id="conv-0",
+        conv_states=cs,
+        temporal_states=ts,
+        fill_ids=[999],
+    )
+
+    # Old canonical rid-0 must be gone
+    assert "rid-0" not in scheduler.pending_restore_registry
+    # conv-0 alias points at rid-NEW
+    assert scheduler.pending_restore_aliases.get("conv-0") == "rid-NEW"
+
+    # Hydration via old rid-0 must be a true miss (None), not resurrect stale state
+    req = _make_req("rid-0")
+    result = scheduler._maybe_hydrate_from_pending_restore(req)
+    assert result is None
+
+    # Hydration via alias conv-0 hits the new canonical rid-NEW
+    req2 = _make_req("rid-different", conversation_id="conv-0")
+    result2 = scheduler._maybe_hydrate_from_pending_restore(req2)
+    assert result2 is True
+    assert req2.mamba_pool_idx is not None
+
+
+# ---------------------------------------------------------------------------
 # Consumer tests — _maybe_hydrate_from_pending_restore
 # ---------------------------------------------------------------------------
 

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -85,10 +85,12 @@ def _build_scheduler():
 
 
 def _make_state(value: float = 1.0):
+    """Build a (conv_states, temporal_states) pair filled with `value`."""
     return [torch.full((1, 2), value)], torch.full((1, 2), value + 1)
 
 
 def _make_req(rid: str, conversation_id=None, mamba_pool_idx=None):
+    """Build a minimal Req-shaped SimpleNamespace for hydration tests."""
     return SimpleNamespace(
         rid=rid,
         conversation_id=conversation_id,

--- a/python/sglang/test/srt/test_pending_restore_registry.py
+++ b/python/sglang/test/srt/test_pending_restore_registry.py
@@ -340,7 +340,7 @@ def test_stage_evicts_old_canonical_when_rid_was_previously_alias():
     # First: rid-P is canonical, conv-R alias → rid-P (so rid-R is an alias)
     scheduler._stage_pending_restore(
         rid="rid-P",
-        conversation_id="conv-R",
+        conversation_id="rid-R",
         conv_states=cs1,
         temporal_states=ts1,
         fill_ids=[1],
@@ -358,8 +358,6 @@ def test_stage_evicts_old_canonical_when_rid_was_previously_alias():
     assert "rid-P" not in scheduler.pending_restore_registry
     # No orphan alias rid-R→rid-P remains
     assert "rid-R" not in scheduler.pending_restore_aliases
-    # The old alias conv-R from the rid-P entry must be gone too
-    assert "conv-R" not in scheduler.pending_restore_aliases
     # Only rid-R canonical exists
     assert len(scheduler.pending_restore_registry) == 1
     assert scheduler.pending_restore_registry["rid-R"].fill_ids == [2]


### PR DESCRIPTION
## Summary

Adds a Scheduler-level pending-restore registry indexed by rid that surfaces restored snapshot state to subsequent requests. Closes the structural gap at `scheduler.py:1838-1853` where `handle_restore_snapshot` returned success but never staged the loaded state in any consumable registry.

Closes #64.

## Background

Phase 1 investigation confirmed `handle_restore_snapshot` was a stub-success implementation: returned "Snapshot state available for future requests" but never loaded the snapshot into any rid-indexed registry. Combined with the absence of any consumer hook in the chat handler or scheduler request-creation path, restored state was structurally unreachable for subsequent requests. This was an always-existed implementation gap, not a regression.

## Implementation

- Scheduler-level pending-restore registry indexed by rid (and conversation_id alias). `OrderedDict`, max 256 entries, LRU eviction. Entries persist after consumption for multi-turn semantics.
- Producer wired in `handle_restore_snapshot` path-B-without-live-req (replaces the stub-success branch).
- Consumer wired in `handle_generate_request` immediately before `init_req_max_new_tokens`. Strategy A: leaves `req.origin_input_ids` as the new turn only — Mamba state in the pool slot carries prior conversation.
- 305 lines added to `scheduler.py`, 280-line test file, 11 new unit tests + 26 existing snapshot tests pass. Pre-commit clean.

## Verification

End-to-end smoke test on pure-Mamba2 Codestral 7B v0.1 via `/generate` path confirmed the registry mechanically works:

- Establish: prefill 25 tokens, snapshot save with `token_count=25`
- Recall: registry HIT, `mamba_pool_idx=6` allocated, Strategy A semantics confirmed via prefill processing only the new 10 tokens

The initial Test 4 stateful recall failure on the standalone recall prompt ("What was the secret code I told you?") was disambiguated to a **model-capability / prompt-surface-form confound**, not a registry defect. A baseline diagnostic (no snapshots, full context inline) showed Codestral 7B base recalls correctly when given the inline single-shot prompt but fails when the recall is wrapped in pseudo-conversation `User:`/`Assistant:` role markers. The model pattern-matches the standalone recall question against internet refusal templates regardless of state.

The registry is verified. The recall surface form is the test-methodology limitation.

Granite hybrid `validate-sync.sh` result was 4/5 PASS with Test 4 fail. The same prompt-surface-form caveat applies, plus hybrid-class concerns (attention KV restoration alongside SSM state) that are out of scope for this registry-only fix. Tracked separately as follow-up.

## Side findings (separate tickets)

- KHA-356 / GH #63: `SGLANG_ENABLE_SPEC_V2` became `True` as upstream default at commit `79dbfe4505`, breaks `validate-sync.sh` startup unless `SGLANG_ENABLE_SPEC_V2=0` is set. Workaround documented.
- KHA-359: `post_forward_snapshot_callback` fires `int(None)` on warmup probe. Pre-existing, unrelated.

## Backup architecture staged

If this approach hits scaling or lifecycle issues in production, KHA-358 stages tier-manager auto-promotion as an alternate fix path with detailed pros/cons.

Refs KHA-348.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounded LRU pending-restore registry with conversation-ID aliasing to stage snapshots; staged restores can hydrate incoming requests or be cleared when a live restore succeeds. Failed hydrations now abort/defer requests and avoid applying stale state.

* **Tests**
  * Comprehensive tests for staging, aliasing, eviction, tri-state hydration (hit/miss/pool-exhausted), error handling, and multi-request semantics.

* **Chores**
  * Added a Triton compiler stub for improved compatibility where Triton is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->