### PR TITLE
feat(benchmarks): LoCoMo harness for Engram validation (KHA-255 part 1 of 4)

### DIFF
--- a/docs/benchmarks/locomo-spec-2026-05-03.md
+++ b/docs/benchmarks/locomo-spec-2026-05-03.md
@@ -1,0 +1,169 @@
+# LoCoMo Benchmark Spec — Engram KHA-255
+**Date**: 2026-05-03  
+**Ticket**: [KHA-255](https://linear.app/khaentertainment/issue/KHA-255/recognized-benchmark-suite-for-engram-validation)  
+**Branch**: `feat/kha-255-locomo-harness-prep`  
+**Harness**: `scripts/benchmarks/locomo_runner.py`
+
+---
+
+## Goal
+
+Produce credible, reproducible LoCoMo QA scores comparing:
+
+1. **Stateless baseline** — standard LLM inference, full conversation context injected on every question, no snapshot persistence.
+2. **Engram mode** — snapshot save/restore via KHA-348 fix; model builds state incrementally then restores per question.
+
+The primary claim under test: **Engram mode matches or exceeds stateless baseline on LoCoMo F1**, demonstrating that snapshot-based state recall is functionally correct and not regressive.
+
+Secondary measurement: **snapshot save/restore latency at LoCoMo scale** (~500–700 turns per conversation), relevant to the locus-of-intelligence demo.
+
+---
+
+## What Success Looks Like
+
+| Condition | Threshold |
+|-----------|-----------|
+| Engram overall F1 ≥ stateless overall F1 − 0.02 | Core parity claim validated |
+| Engram per-category F1 ≥ stateless per-category F1 − 0.05 | No category-level regression |
+| Mean restore latency ≤ 200ms | Acceptable for interactive demo |
+| All 1986 questions scored, no crashes | Run completed cleanly |
+
+Results suitable for grant applications / partner decks require a full 10-conversation run on both modes.
+
+---
+
+## Models in Scope
+
+### Smoke run (must pass before full run)
+- **Granite-4.0-H-tiny** (IBM, ~4B, FP16)  
+  - Path on OVH: `/mnt/models/granite-4.0-h-tiny` (staged from S3 during RunPod wind-down)
+  - Purpose: fast iteration, validates harness end-to-end in <30 min
+  - Target: 1 conversation (`--conversations 1`), 199 QA items
+
+### Full run — primary
+- **Nemotron-3-Super-120B-A12B** (NVIDIA, FP8)  
+  - Leads all publishable results per KHA-255 model priority
+  - 120B total / 12B active MoE; native 1M context; leads RULER 128K (0.917)
+  - Snapshot size: ~5.3 GB — best demo of constant-size property at scale
+  - Run all 10 conversations on both modes
+
+### Full run — secondary (time/budget permitting)
+- **Qwen3-Coder-Next** (~75B, Alibaba, FP8)  
+  - Cross-vendor story; GLA architecture proves Engram works beyond Mamba2
+  - Snapshot size: ~23.7 GB
+
+### Deferred (not this session)
+- Granite-4.0-H-small (32B) — edge story, local hardware only
+- Any Omni, Cascade, or Mamba-3 variants
+- Any model not listed above
+
+---
+
+## Context Length Plan
+
+LoCoMo conversations range from ~12K to ~45K tokens (plain text, no images).
+
+| Model | Max context | Policy |
+|-------|-------------|--------|
+| Granite-4.0-H-tiny | 32K | Truncate to most recent 28K turns if needed |
+| Nemotron-3-Super-120B | 1M native | No truncation required |
+| Qwen3-Coder-Next | 128K | Truncate to most recent 120K if needed |
+
+**Truncation policy**: truncate from the oldest session forward, preserving the most recent sessions. Log truncated conversation IDs and counts in the output JSON.
+
+---
+
+## Conditions
+
+| Condition | `--mode` | Snapshot ops | Notes |
+|-----------|----------|--------------|-------|
+| Stateless baseline | `stateless` | None | Context injected fresh per question |
+| Engram | `engram` | save after full context load, restore per QA | Exercises KHA-348 fix |
+
+Run both conditions on the same model back-to-back. Order: stateless first (establishes baseline before engram mode touches snapshot state).
+
+---
+
+## Success Criteria
+
+### Green — proceed to full run
+Smoke passes if all of:
+- Harness completes 1 conversation without crash
+- Stateless F1 on conv-26 (199 questions) ≥ 0.10 (minimal sanity — model is answering)
+- Engram F1 on conv-26 ≥ stateless F1 − 0.05
+- At least one restore latency measurement recorded
+
+### Red — STOP and escalate
+Stop immediately if any of:
+- **Engram F1 matches stateless within noise (<0.01 difference) AND both are near-zero**  
+  This pattern indicates KHA-348 is regressed — the snapshot restore is not providing context.
+- Any `restore_snapshot` call returns `success: false`
+- Server crashes or OOM during context loading
+- Harness throws unhandled exception
+
+### Anomalous — flag but continue with caution
+- Engram F1 > stateless F1 by more than 0.10 (unexpected; check for scoring bug)
+- Restore latency > 500ms mean (acceptable for this run but flag for optimization)
+- Category 5 (adversarial) score < 0.20 on either mode (model not following "no info" instruction)
+
+---
+
+## Output Destination
+
+All results written to:
+
+```
+s3://engram/benchmark-results/locomo/
+  locomo_stateless_<model>_<timestamp>.json
+  locomo_stateless_<model>_<timestamp>_summary.csv
+  locomo_engram_<model>_<timestamp>.json
+  locomo_engram_<model>_<timestamp>_summary.csv
+```
+
+---
+
+## Estimated GPU Hours and Cost
+
+Estimates assume OVH H100 PCIe 80GB @ ~$2.49/hr (OVH public pricing, subject to change).
+
+| Condition | Model | Conversations | Est. hours | Est. cost |
+|-----------|-------|--------------|------------|-----------|
+| Smoke (stateless + engram) | Granite-4.0-H-tiny | 1 | 0.5 | ~$1.25 |
+| Full stateless | Nemotron-120B FP8 | 10 | 4–6 | ~$10–15 |
+| Full engram | Nemotron-120B FP8 | 10 | 5–8 | ~$12–20 |
+| Full stateless | Qwen3-75B FP8 | 10 | 3–5 | ~$7–12 |
+| Full engram | Qwen3-75B FP8 | 10 | 4–6 | ~$10–15 |
+| **Re-run budget (1x)** | Both | 10 each | 10–14 | ~$25–35 |
+| **Total (smoke + primary + secondary + reruns)** | | | **~30–45** | **~$75–110** |
+
+Well under $1,000 with significant margin. If secondary model is skipped: ~$50–60.
+
+---
+
+## Pre-flight Gates (run before smoke)
+
+```bash
+# 1. Verify KHA-348 fix is in git history
+python3 scripts/benchmarks/preflight_kha348.py
+# Exit 0 = proceed; Exit 1 = STOP, fix not present
+
+# 2. Verify repo is clean and within 5 commits of origin/main
+bash scripts/benchmarks/preflight_base.sh
+# Exit 0 = proceed; Exit 1 = STOP, sync first
+```
+
+Both must exit 0 before smoke run begins.
+
+---
+
+## Escalation Rule
+
+If engram mode matches stateless mode within noise (|engram_f1 - stateless_f1| < 0.01) on the smoke **and** both scores are within normal range (not trivially near-zero), stop the benchmark, file a regression ticket against KHA-348, and do not run the full suite. The fix must be re-investigated before results are meaningful.
+
+---
+
+## Notes
+
+- Images are not available in the LoCoMo dataset. Turns with `img_url` are passed with `blip_caption` as text substitute. This is consistent with other LLM evals on this dataset.
+- Dataset source: `s3://engram/datasets/locomo/v1/locomo10.json`
+- Harness repo: `feat/kha-255-locomo-harness-prep` branch; do not merge until smoke validates end-to-end.

--- a/scripts/benchmarks/locomo_runner.py
+++ b/scripts/benchmarks/locomo_runner.py
@@ -1,0 +1,442 @@
+"""
+LoCoMo benchmark runner for Engram stateful recall evaluation (KHA-255).
+
+Modes:
+  stateless  — baseline, each question is answered with full conversation context
+               but no snapshot save/restore and no rid reuse across questions.
+  engram     — exercises rid reuse + save/restore: conversation context is built
+               incrementally via snapshot persistence, exercising the KHA-348 fix path.
+
+Usage:
+  python scripts/benchmarks/locomo_runner.py \
+    --mode {stateless,engram} \
+    --model <model-id> \
+    --server-url http://localhost:30000 \
+    --dataset-path data/locomo10.json \
+    --conversations all \
+    --output-dir s3://engram/benchmark-results/locomo/
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+import uuid
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers (mirrors official LoCoMo eval logic exactly)
+# ---------------------------------------------------------------------------
+
+def _normalize(text: str) -> str:
+    import re
+    import string
+    text = text.lower()
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    text = re.sub(r"\b(a|an|the)\b", " ", text)
+    return " ".join(text.split())
+
+
+def _token_f1(prediction: str, ground_truth: str) -> float:
+    pred_tokens = _normalize(prediction).split()
+    gold_tokens = _normalize(ground_truth).split()
+    if not pred_tokens or not gold_tokens:
+        return float(pred_tokens == gold_tokens)
+    common = set(pred_tokens) & set(gold_tokens)
+    num_common = sum(min(pred_tokens.count(t), gold_tokens.count(t)) for t in common)
+    if num_common == 0:
+        return 0.0
+    precision = num_common / len(pred_tokens)
+    recall = num_common / len(gold_tokens)
+    return (2 * precision * recall) / (precision + recall)
+
+
+def _partial_f1(prediction: str, ground_truth: str) -> float:
+    """Category 1: split answer into sub-phrases, average F1 across each."""
+    parts = [p.strip() for p in ground_truth.split(",") if p.strip()]
+    if not parts:
+        return _token_f1(prediction, ground_truth)
+    return sum(_token_f1(prediction, p) for p in parts) / len(parts)
+
+
+def score_qa(prediction: str, qa: dict) -> float:
+    """Return [0,1] score for a single QA item using the official LoCoMo rubric."""
+    category = qa["category"]
+    if category == 5:
+        # adversarial: model should say it doesn't know
+        lower = prediction.lower()
+        return 1.0 if ("no information available" in lower or "not mentioned" in lower) else 0.0
+    answer = qa.get("answer", "")
+    if category == 3:
+        answer = answer.split(";")[0].strip()
+    if category == 1:
+        return _partial_f1(prediction, answer)
+    # categories 2, 3, 4
+    return _token_f1(prediction, answer)
+
+
+# ---------------------------------------------------------------------------
+# Dataset loader
+# ---------------------------------------------------------------------------
+
+def load_dataset(path: str, max_conversations: int | None = None) -> list[dict]:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Dataset not found: {path}")
+    with open(p) as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("Expected top-level JSON array in dataset file")
+    if max_conversations is not None:
+        data = data[:max_conversations]
+    return data
+
+
+def flatten_conversation(conv: dict) -> list[dict]:
+    """Return all turns in chronological session order as a flat list of dicts."""
+    turns = []
+    for n in range(1, 200):
+        key = f"session_{n}"
+        if key not in conv:
+            break
+        session_turns = conv[key]
+        if not isinstance(session_turns, list):
+            continue
+        date = conv.get(f"{key}_date_time", "")
+        for turn in session_turns:
+            turns.append({
+                "session": n,
+                "date": date,
+                "speaker": turn.get("speaker", ""),
+                "dia_id": turn.get("dia_id", ""),
+                "text": turn.get("text", ""),
+                "blip_caption": turn.get("blip_caption", ""),
+            })
+    return turns
+
+
+def build_context_text(turns: list[dict]) -> str:
+    lines = []
+    for t in turns:
+        line = f"{t['speaker']}: {t['text']}"
+        if t.get("blip_caption"):
+            line += f" [image: {t['blip_caption']}]"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+def chat_completion(
+    server_url: str,
+    model: str,
+    messages: list[dict],
+    rid: str | None = None,
+    dry_run: bool = False,
+    dry_run_answer: str = "dry-run-answer",
+) -> tuple[str, float]:
+    """Return (answer_text, latency_seconds)."""
+    if dry_run:
+        return dry_run_answer, 0.001
+
+    import urllib.request
+
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": 128,
+        "temperature": 0.0,
+    }
+    if rid is not None:
+        payload["rid"] = rid
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{server_url}/v1/chat/completions",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        body = json.loads(resp.read())
+    latency = time.perf_counter() - t0
+    answer = body["choices"][0]["message"]["content"].strip()
+    return answer, latency
+
+
+def save_snapshot(server_url: str, rid: str, dry_run: bool = False) -> tuple[bool, float]:
+    if dry_run:
+        return True, 0.001
+    import urllib.request
+    payload = json.dumps({"rid": rid}).encode()
+    req = urllib.request.Request(
+        f"{server_url}/save_snapshot",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+    latency = time.perf_counter() - t0
+    return body.get("success", False), latency
+
+
+def restore_snapshot(server_url: str, rid: str, dry_run: bool = False) -> tuple[bool, float]:
+    if dry_run:
+        return True, 0.001
+    import urllib.request
+    payload = json.dumps({"rid": rid}).encode()
+    req = urllib.request.Request(
+        f"{server_url}/restore_snapshot",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+    latency = time.perf_counter() - t0
+    return body.get("success", False), latency
+
+
+# ---------------------------------------------------------------------------
+# Runner modes
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant with access to a long conversation history. "
+    "Answer questions about the conversation concisely and accurately. "
+    "If the answer is not present in the conversation, say 'No information available'."
+)
+
+QA_PROMPT_TEMPLATE = "Based on the conversation above, answer the following question:\n{question}"
+
+
+def run_stateless(
+    sample: dict,
+    server_url: str,
+    model: str,
+    dry_run: bool,
+) -> list[dict]:
+    """One fresh request per QA item. Baseline — no snapshot, no rid reuse."""
+    turns = flatten_conversation(sample["conversation"])
+    context = build_context_text(turns)
+    results = []
+    for qa in sample["qa"]:
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": context + "\n\n" + QA_PROMPT_TEMPLATE.format(question=qa["question"])},
+        ]
+        answer, latency = chat_completion(server_url, model, messages, dry_run=dry_run)
+        results.append({
+            "dia_id_evidence": qa.get("evidence", []),
+            "question": qa["question"],
+            "ground_truth": qa.get("answer", qa.get("adversarial_answer", "")),
+            "category": qa["category"],
+            "prediction": answer,
+            "score": score_qa(answer, qa),
+            "latency_s": round(latency, 4),
+            "save_latency_s": None,
+            "restore_latency_s": None,
+        })
+    return results
+
+
+def run_engram(
+    sample: dict,
+    server_url: str,
+    model: str,
+    dry_run: bool,
+) -> list[dict]:
+    """
+    Engram mode — exercises rid reuse + save/restore (KHA-348 fix path).
+
+    Protocol:
+    1. Feed conversation turns incrementally to the model via a persistent rid.
+    2. After each session's turns are fed, save snapshot.
+    3. For each QA item, restore snapshot and ask the question with the same rid.
+    4. Measure save/restore latency separately.
+    """
+    rid = f"locomo-{sample['sample_id']}-{uuid.uuid4().hex[:8]}"
+    turns = flatten_conversation(sample["conversation"])
+
+    # Build the conversation context incrementally
+    context_so_far: list[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
+
+    # Feed all turns to establish context
+    for turn in turns:
+        line = f"{turn['speaker']}: {turn['text']}"
+        if turn.get("blip_caption"):
+            line += f" [image: {turn['blip_caption']}]"
+        context_so_far.append({"role": "user", "content": line})
+        # Fire-and-forget to build state; we only care about the final answer
+        chat_completion(server_url, model, context_so_far, rid=rid, dry_run=dry_run,
+                        dry_run_answer="[context feeding]")
+        context_so_far.append({"role": "assistant", "content": "[context feeding]"})
+
+    # Save snapshot after full context is loaded
+    save_ok, save_latency = save_snapshot(server_url, rid, dry_run=dry_run)
+    if not save_ok and not dry_run:
+        raise RuntimeError(f"save_snapshot failed for rid={rid}")
+
+    results = []
+    for qa in sample["qa"]:
+        restore_ok, restore_latency = restore_snapshot(server_url, rid, dry_run=dry_run)
+        if not restore_ok and not dry_run:
+            raise RuntimeError(f"restore_snapshot failed for rid={rid}")
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": QA_PROMPT_TEMPLATE.format(question=qa["question"])},
+        ]
+        answer, latency = chat_completion(server_url, model, messages, rid=rid, dry_run=dry_run)
+        results.append({
+            "dia_id_evidence": qa.get("evidence", []),
+            "question": qa["question"],
+            "ground_truth": qa.get("answer", qa.get("adversarial_answer", "")),
+            "category": qa["category"],
+            "prediction": answer,
+            "score": score_qa(answer, qa),
+            "latency_s": round(latency, 4),
+            "save_latency_s": round(save_latency, 4),
+            "restore_latency_s": round(restore_latency, 4),
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def write_outputs(results_by_conv: dict[str, list[dict]], output_dir: str, mode: str, model: str) -> tuple[str, str]:
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    stem = f"locomo_{mode}_{model.replace('/', '-')}_{timestamp}"
+
+    all_results = []
+    for conv_id, qa_results in results_by_conv.items():
+        all_results.append({"conv_id": conv_id, "qa_results": qa_results})
+
+    # Aggregate stats
+    flat_qa = [r for v in results_by_conv.values() for r in v]
+    by_cat: dict[int, list[float]] = defaultdict(list)
+    for r in flat_qa:
+        by_cat[r["category"]].append(r["score"])
+    overall = sum(r["score"] for r in flat_qa) / len(flat_qa) if flat_qa else 0.0
+    cat_means = {cat: sum(scores) / len(scores) for cat, scores in by_cat.items()}
+
+    save_lats = [r["save_latency_s"] for r in flat_qa if r["save_latency_s"] is not None]
+    restore_lats = [r["restore_latency_s"] for r in flat_qa if r["restore_latency_s"] is not None]
+
+    summary = {
+        "mode": mode,
+        "model": model,
+        "timestamp": timestamp,
+        "total_questions": len(flat_qa),
+        "overall_f1": round(overall, 4),
+        "f1_by_category": {str(k): round(v, 4) for k, v in sorted(cat_means.items())},
+        "mean_save_latency_s": round(sum(save_lats) / len(save_lats), 4) if save_lats else None,
+        "mean_restore_latency_s": round(sum(restore_lats) / len(restore_lats), 4) if restore_lats else None,
+        "conversations": all_results,
+    }
+
+    output_dir = output_dir.rstrip("/")
+    json_path = f"{output_dir}/{stem}.json"
+    csv_path = f"{output_dir}/{stem}_summary.csv"
+
+    if output_dir.startswith("s3://"):
+        import subprocess
+        json_tmp = f"/tmp/{stem}.json"
+        csv_tmp = f"/tmp/{stem}_summary.csv"
+        with open(json_tmp, "w") as f:
+            json.dump(summary, f, indent=2)
+        subprocess.run(["aws", "s3", "cp", json_tmp, json_path], check=True)
+        _write_csv(flat_qa, csv_tmp)
+        subprocess.run(["aws", "s3", "cp", csv_tmp, csv_path], check=True)
+    else:
+        os.makedirs(output_dir, exist_ok=True)
+        with open(json_path, "w") as f:
+            json.dump(summary, f, indent=2)
+        _write_csv(flat_qa, csv_path)
+
+    return json_path, csv_path
+
+
+def _write_csv(flat_qa: list[dict], path: str) -> None:
+    fields = ["question", "category", "ground_truth", "prediction", "score",
+              "latency_s", "save_latency_s", "restore_latency_s"]
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(flat_qa)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="LoCoMo benchmark runner for Engram (KHA-255)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--mode", required=True, choices=["stateless", "engram"],
+                   help="stateless=baseline, engram=snapshot save/restore")
+    p.add_argument("--model", required=True,
+                   help="Model ID passed to /v1/chat/completions")
+    p.add_argument("--server-url", default="http://localhost:30000",
+                   help="Base URL of the Engram/SGLang server")
+    p.add_argument("--dataset-path", required=True,
+                   help="Path to locomo10.json (local or s3://)")
+    p.add_argument("--conversations", default="all",
+                   help="Number of conversations to run, or 'all'")
+    p.add_argument("--output-dir", required=True,
+                   help="Output directory (local path or s3://bucket/prefix)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Mock server responses for unit testing without a live model")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    max_conv = None if args.conversations == "all" else int(args.conversations)
+    dataset = load_dataset(args.dataset_path, max_conversations=max_conv)
+    print(f"Loaded {len(dataset)} conversations from {args.dataset_path}", flush=True)
+
+    run_fn = run_engram if args.mode == "engram" else run_stateless
+
+    results_by_conv: dict[str, list[dict]] = {}
+    total_start = time.perf_counter()
+
+    for i, sample in enumerate(dataset):
+        conv_id = sample["sample_id"]
+        print(f"[{i+1}/{len(dataset)}] {conv_id} ...", flush=True)
+        results_by_conv[conv_id] = run_fn(
+            sample=sample,
+            server_url=args.server_url,
+            model=args.model,
+            dry_run=args.dry_run,
+        )
+
+    wall_clock = time.perf_counter() - total_start
+    print(f"Total wall-clock: {wall_clock:.1f}s", flush=True)
+
+    json_path, csv_path = write_outputs(results_by_conv, args.output_dir, args.mode, args.model)
+    print(f"Results: {json_path}")
+    print(f"Summary: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/locomo_runner.py
+++ b/scripts/benchmarks/locomo_runner.py
@@ -361,9 +361,9 @@ def write_outputs(results_by_conv: dict[str, list[dict]], output_dir: str, mode:
         csv_tmp = f"/tmp/{stem}_summary.csv"
         with open(json_tmp, "w") as f:
             json.dump(summary, f, indent=2)
-        subprocess.run(["aws", "s3", "cp", json_tmp, json_path], check=True)
+        subprocess.run(["s3cmd", "put", json_tmp, json_path], check=True)
         _write_csv(flat_qa, csv_tmp)
-        subprocess.run(["aws", "s3", "cp", csv_tmp, csv_path], check=True)
+        subprocess.run(["s3cmd", "put", csv_tmp, csv_path], check=True)
     else:
         os.makedirs(output_dir, exist_ok=True)
         with open(json_path, "w") as f:

--- a/scripts/benchmarks/preflight_base.sh
+++ b/scripts/benchmarks/preflight_base.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# preflight_base.sh — verify repo is within 5 commits of origin/main
+# and has no unresolved conflict markers in tracked files.
+#
+# Exit 0 — clean; safe to proceed.
+# Exit 1 — diagnostic printed; do not run benchmark.
+#
+# Usage: bash scripts/benchmarks/preflight_base.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=1
+MAX_COMMITS_BEHIND=5
+
+echo "=== preflight_base: repo sync check ==="
+
+# ---- 1. Fetch latest origin/main ----
+echo "[preflight] Fetching origin/main ..."
+git fetch origin main 2>&1
+
+# ---- 2. Compare HEAD to origin/main ----
+BEHIND=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo "error")
+AHEAD=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo "error")
+
+if [[ "$BEHIND" == "error" || "$AHEAD" == "error" ]]; then
+  echo "[preflight] ERROR: could not compute ahead/behind count." >&2
+  exit $FAIL
+fi
+
+echo "[preflight] HEAD is ${AHEAD} commit(s) ahead and ${BEHIND} commit(s) behind origin/main."
+
+if [[ "$BEHIND" -gt "$MAX_COMMITS_BEHIND" ]]; then
+  echo "[preflight] FAIL: HEAD is ${BEHIND} commits behind origin/main (max allowed: ${MAX_COMMITS_BEHIND})." >&2
+  echo "[preflight] Run: git merge origin/main" >&2
+  exit $FAIL
+fi
+
+# ---- 3. Check for unresolved conflict markers ----
+echo "[preflight] Checking for unresolved conflict markers ..."
+
+CONFLICT_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null) || true
+if [[ -n "$CONFLICT_FILES" ]]; then
+  echo "[preflight] FAIL: unresolved merge conflicts in:" >&2
+  echo "$CONFLICT_FILES" >&2
+  exit $FAIL
+fi
+
+# Also grep tracked text files for inline markers (catches manually-added markers)
+MARKER_FILES=$(git grep -l "^<<<<<<< \|^>>>>>>> \|^=======$" -- '*.py' '*.sh' '*.json' '*.md' 2>/dev/null || true)
+if [[ -n "$MARKER_FILES" ]]; then
+  echo "[preflight] FAIL: conflict markers found in:" >&2
+  echo "$MARKER_FILES" >&2
+  exit $FAIL
+fi
+
+echo ""
+echo "[preflight] PASS — repo is clean and within ${MAX_COMMITS_BEHIND} commits of origin/main."
+exit $PASS

--- a/scripts/benchmarks/preflight_kha348.py
+++ b/scripts/benchmarks/preflight_kha348.py
@@ -1,0 +1,95 @@
+"""
+Pre-flight check: verify KHA-348 fix is merged and present in local main.
+
+Exit 0  — fix confirmed in main, safe to proceed.
+Exit 1  — fix not confirmed; diagnostic printed to stderr.
+
+Usage: python scripts/benchmarks/preflight_kha348.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Known good commits introduced by the KHA-348 fix branch.
+# Update this list if the fix is squash-merged under a different SHA.
+KHA348_FIX_COMMITS = [
+    "bfc58ee8a",  # fix(snapshot): live-restore clears pending entry + conv_id conflict resolution
+    "c5b958c55",  # fix(snapshot): live-restore path syncs req.conversation_id with effective_conv_id
+]
+
+KHA348_LINEAR_URL = (
+    "https://linear.app/khaentertainment/issue/KHA-348/"
+    "v1chatcompletions-does-not-rehydrate-restored-snapshot-state-across"
+)
+
+
+def run(cmd: list[str]) -> tuple[int, str]:
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    return r.returncode, r.stdout.strip()
+
+
+def check_linear_status() -> bool:
+    """
+    Attempts a lightweight check via the gh CLI if available.
+    Falls back to True (non-blocking) when gh is not configured.
+    This is best-effort; the git-log check below is authoritative.
+    """
+    rc, _ = run(["which", "gh"])
+    if rc != 0:
+        print("[preflight] gh CLI not found — skipping Linear API check (non-blocking)", flush=True)
+        return True
+    print(f"[preflight] KHA-348 Linear: {KHA348_LINEAR_URL}", flush=True)
+    return True
+
+
+def check_git_log() -> bool:
+    """Verify at least one KHA-348 fix commit is reachable from HEAD."""
+    rc, log = run(["git", "log", "--oneline", "-200"])
+    if rc != 0:
+        print("[preflight] ERROR: git log failed", file=sys.stderr)
+        return False
+    for sha in KHA348_FIX_COMMITS:
+        if sha in log:
+            print(f"[preflight] KHA-348 fix commit found in git log: {sha}", flush=True)
+            return True
+    print("[preflight] ERROR: KHA-348 fix commits not found in last 200 log entries.", file=sys.stderr)
+    print(f"[preflight] Expected one of: {KHA348_FIX_COMMITS}", file=sys.stderr)
+    print("[preflight] Run: git fetch origin main && git merge origin/main", file=sys.stderr)
+    return False
+
+
+def check_main_branch() -> bool:
+    """Warn (non-blocking) if we're not on main."""
+    rc, branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if branch != "main":
+        print(f"[preflight] WARNING: not on main branch (current: {branch})", flush=True)
+        print("[preflight] KHA-348 fix must be reachable from the branch used for benchmarking.", flush=True)
+    return True
+
+
+def main() -> None:
+    print("=== preflight_kha348: verifying KHA-348 fix is present ===", flush=True)
+    failures = []
+
+    check_main_branch()
+
+    if not check_linear_status():
+        failures.append("Linear status check failed")
+
+    if not check_git_log():
+        failures.append("KHA-348 fix commits not found in git log")
+
+    if failures:
+        print("\n[preflight] FAIL — KHA-348 fix not confirmed.", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\n[preflight] PASS — KHA-348 fix confirmed in git history.", flush=True)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/test_locomo_runner.py
+++ b/tests/benchmarks/test_locomo_runner.py
@@ -1,0 +1,397 @@
+"""
+Unit tests for scripts/benchmarks/locomo_runner.py.
+
+All tests run on CPU with no model server (dry_run=True or mocked calls).
+Run: pytest tests/benchmarks/test_locomo_runner.py -v
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Ensure the scripts directory is importable
+sys.path.insert(0, str(Path(__file__).parents[2] / "scripts" / "benchmarks"))
+
+from locomo_runner import (
+    _normalize,
+    _token_f1,
+    _partial_f1,
+    build_context_text,
+    flatten_conversation,
+    load_dataset,
+    main,
+    parse_args,
+    run_engram,
+    run_stateless,
+    score_qa,
+    write_outputs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_conversation(num_sessions: int = 2, turns_per_session: int = 3) -> dict:
+    conv = {
+        "speaker_a": "Alice",
+        "speaker_b": "Bob",
+    }
+    dia = 0
+    for s in range(1, num_sessions + 1):
+        conv[f"session_{s}_date_time"] = f"2023-0{s}-01T10:00:00"
+        turns = []
+        for t in range(1, turns_per_session + 1):
+            dia += 1
+            turns.append({
+                "speaker": "Alice" if t % 2 == 1 else "Bob",
+                "dia_id": f"D{s}:{t}",
+                "text": f"Session {s} turn {t} content.",
+            })
+        conv[f"session_{s}"] = turns
+    return conv
+
+
+def _make_sample(sample_id: str = "conv-test", qa: list | None = None) -> dict:
+    if qa is None:
+        qa = [
+            {"question": "What did Alice say first?", "answer": "Session 1 turn 1 content.",
+             "evidence": ["D1:1"], "category": 4},
+            {"question": "When was session 1?", "answer": "2023-01-01",
+             "evidence": ["D1:1"], "category": 2},
+            {"question": "Did Alice discuss invisible things?", "adversarial_answer": "yes",
+             "evidence": [], "category": 5},
+        ]
+    return {
+        "sample_id": sample_id,
+        "conversation": _make_conversation(),
+        "qa": qa,
+        "event_summary": {},
+        "observation": {},
+        "session_summary": {},
+    }
+
+
+def _write_dataset(path: str, samples: list) -> None:
+    with open(path, "w") as f:
+        json.dump(samples, f)
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+class TestArgparse:
+    def test_required_mode(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--model", "m", "--dataset-path", "x", "--output-dir", "y"])
+
+    def test_stateless_mode(self):
+        args = parse_args([
+            "--mode", "stateless", "--model", "m",
+            "--dataset-path", "x", "--output-dir", "y",
+        ])
+        assert args.mode == "stateless"
+        assert args.dry_run is False
+
+    def test_engram_mode(self):
+        args = parse_args([
+            "--mode", "engram", "--model", "m",
+            "--dataset-path", "x", "--output-dir", "y",
+            "--dry-run",
+        ])
+        assert args.mode == "engram"
+        assert args.dry_run is True
+
+    def test_conversations_all(self):
+        args = parse_args([
+            "--mode", "stateless", "--model", "m",
+            "--dataset-path", "x", "--output-dir", "y",
+        ])
+        assert args.conversations == "all"
+
+    def test_conversations_int(self):
+        args = parse_args([
+            "--mode", "stateless", "--model", "m",
+            "--dataset-path", "x", "--output-dir", "y",
+            "--conversations", "3",
+        ])
+        assert args.conversations == "3"
+
+
+# ---------------------------------------------------------------------------
+# Dataset loader
+# ---------------------------------------------------------------------------
+
+class TestDatasetLoader:
+    def test_load_basic(self, tmp_path):
+        f = tmp_path / "test.json"
+        samples = [_make_sample("conv-1"), _make_sample("conv-2")]
+        _write_dataset(str(f), samples)
+        data = load_dataset(str(f))
+        assert len(data) == 2
+        assert data[0]["sample_id"] == "conv-1"
+
+    def test_load_max_conversations(self, tmp_path):
+        f = tmp_path / "test.json"
+        samples = [_make_sample(f"conv-{i}") for i in range(5)]
+        _write_dataset(str(f), samples)
+        data = load_dataset(str(f), max_conversations=2)
+        assert len(data) == 2
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_dataset("/nonexistent/path.json")
+
+    def test_non_list_raises(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text('{"not": "a list"}')
+        with pytest.raises(ValueError):
+            load_dataset(str(f))
+
+
+# ---------------------------------------------------------------------------
+# Conversation flattening
+# ---------------------------------------------------------------------------
+
+class TestFlattenConversation:
+    def test_turn_count(self):
+        conv = _make_conversation(num_sessions=2, turns_per_session=3)
+        turns = flatten_conversation(conv)
+        assert len(turns) == 6
+
+    def test_session_order(self):
+        conv = _make_conversation(num_sessions=3, turns_per_session=1)
+        turns = flatten_conversation(conv)
+        assert [t["session"] for t in turns] == [1, 2, 3]
+
+    def test_dia_id_preserved(self):
+        conv = _make_conversation(num_sessions=1, turns_per_session=2)
+        turns = flatten_conversation(conv)
+        assert turns[0]["dia_id"] == "D1:1"
+        assert turns[1]["dia_id"] == "D1:2"
+
+    def test_blip_caption_included(self):
+        conv = _make_conversation(num_sessions=1, turns_per_session=1)
+        conv["session_1"][0]["blip_caption"] = "a photo of a cat"
+        turns = flatten_conversation(conv)
+        assert turns[0]["blip_caption"] == "a photo of a cat"
+
+    def test_build_context_text(self):
+        turns = [
+            {"speaker": "Alice", "text": "Hello.", "blip_caption": ""},
+            {"speaker": "Bob", "text": "Hi!", "blip_caption": "a sunset"},
+        ]
+        ctx = build_context_text(turns)
+        assert "Alice: Hello." in ctx
+        assert "Bob: Hi! [image: a sunset]" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+class TestScoring:
+    def test_cat4_exact(self):
+        qa = {"category": 4, "answer": "adoption agencies"}
+        assert score_qa("adoption agencies", qa) == pytest.approx(1.0)
+
+    def test_cat4_partial(self):
+        qa = {"category": 4, "answer": "the quick brown fox"}
+        score = score_qa("the quick fox", qa)
+        assert 0 < score < 1.0
+
+    def test_cat4_no_match(self):
+        qa = {"category": 4, "answer": "xyz"}
+        assert score_qa("completely different", qa) == 0.0
+
+    def test_cat2_temporal(self):
+        qa = {"category": 2, "answer": "7 May 2023"}
+        assert score_qa("7 May 2023", qa) == pytest.approx(1.0)
+
+    def test_cat3_semicolon(self):
+        qa = {"category": 3, "answer": "psychology; counseling"}
+        score = score_qa("psychology", qa)
+        assert score == pytest.approx(1.0)
+
+    def test_cat1_multi_hop(self):
+        qa = {"category": 1, "answer": "cats, dogs"}
+        assert score_qa("cats and dogs", qa) >= 0.5
+
+    def test_cat5_adversarial_no_info(self):
+        qa = {"category": 5, "adversarial_answer": "self-care"}
+        assert score_qa("No information available in the conversation", qa) == 1.0
+
+    def test_cat5_adversarial_wrong(self):
+        qa = {"category": 5, "adversarial_answer": "self-care"}
+        assert score_qa("self-care is important", qa) == 0.0
+
+    def test_cat5_not_mentioned(self):
+        qa = {"category": 5, "adversarial_answer": "x"}
+        assert score_qa("That's not mentioned in the conversation.", qa) == 1.0
+
+    def test_normalize_strips_articles(self):
+        assert _normalize("the quick brown fox") == "quick brown fox"
+
+    def test_token_f1_symmetry(self):
+        a, b = "hello world", "world hello"
+        assert _token_f1(a, b) == pytest.approx(_token_f1(b, a))
+
+
+# ---------------------------------------------------------------------------
+# Run modes (dry-run)
+# ---------------------------------------------------------------------------
+
+class TestStatelessMode:
+    def test_returns_one_result_per_qa(self):
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "test-model", dry_run=True)
+        assert len(results) == len(sample["qa"])
+
+    def test_result_schema(self):
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "test-model", dry_run=True)
+        r = results[0]
+        assert "question" in r
+        assert "prediction" in r
+        assert "score" in r
+        assert "latency_s" in r
+        assert r["save_latency_s"] is None
+        assert r["restore_latency_s"] is None
+
+    def test_score_is_float_in_range(self):
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "test-model", dry_run=True)
+        for r in results:
+            assert 0.0 <= r["score"] <= 1.0
+
+
+class TestEngramMode:
+    def test_returns_one_result_per_qa(self):
+        sample = _make_sample()
+        results = run_engram(sample, "http://unused", "test-model", dry_run=True)
+        assert len(results) == len(sample["qa"])
+
+    def test_result_has_save_restore_latency(self):
+        sample = _make_sample()
+        results = run_engram(sample, "http://unused", "test-model", dry_run=True)
+        r = results[0]
+        assert r["save_latency_s"] is not None
+        assert r["restore_latency_s"] is not None
+        assert r["save_latency_s"] > 0
+        assert r["restore_latency_s"] > 0
+
+    def test_score_is_float_in_range(self):
+        sample = _make_sample()
+        results = run_engram(sample, "http://unused", "test-model", dry_run=True)
+        for r in results:
+            assert 0.0 <= r["score"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+class TestOutputSchema:
+    def test_json_output_valid(self, tmp_path):
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "model", dry_run=True)
+        json_path, csv_path = write_outputs(
+            {"conv-test": results}, str(tmp_path), "stateless", "model"
+        )
+        with open(json_path) as f:
+            data = json.load(f)
+        assert data["mode"] == "stateless"
+        assert data["model"] == "model"
+        assert "overall_f1" in data
+        assert "f1_by_category" in data
+        assert "total_questions" in data
+        assert data["total_questions"] == len(sample["qa"])
+
+    def test_csv_output_valid(self, tmp_path):
+        import csv as _csv
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "model", dry_run=True)
+        _, csv_path = write_outputs(
+            {"conv-test": results}, str(tmp_path), "stateless", "model"
+        )
+        with open(csv_path) as f:
+            rows = list(_csv.DictReader(f))
+        assert len(rows) == len(sample["qa"])
+        assert "score" in rows[0]
+        assert "prediction" in rows[0]
+
+    def test_overall_f1_in_range(self, tmp_path):
+        sample = _make_sample()
+        results = run_stateless(sample, "http://unused", "model", dry_run=True)
+        json_path, _ = write_outputs(
+            {"conv-test": results}, str(tmp_path), "stateless", "model"
+        )
+        with open(json_path) as f:
+            data = json.load(f)
+        assert 0.0 <= data["overall_f1"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dry-run (main entry point)
+# ---------------------------------------------------------------------------
+
+class TestDryRunEndToEnd:
+    def test_main_stateless_dry_run(self, tmp_path):
+        dataset_path = str(tmp_path / "dataset.json")
+        _write_dataset(dataset_path, [_make_sample("conv-1")])
+        main([
+            "--mode", "stateless",
+            "--model", "test-model",
+            "--dataset-path", dataset_path,
+            "--conversations", "1",
+            "--output-dir", str(tmp_path / "out"),
+            "--dry-run",
+        ])
+        out_dir = tmp_path / "out"
+        json_files = list(out_dir.glob("*.json"))
+        csv_files = list(out_dir.glob("*.csv"))
+        assert len(json_files) == 1
+        assert len(csv_files) == 1
+
+    def test_main_engram_dry_run(self, tmp_path):
+        dataset_path = str(tmp_path / "dataset.json")
+        _write_dataset(dataset_path, [_make_sample("conv-1")])
+        main([
+            "--mode", "engram",
+            "--model", "test-model",
+            "--dataset-path", dataset_path,
+            "--conversations", "1",
+            "--output-dir", str(tmp_path / "out"),
+            "--dry-run",
+        ])
+        out_dir = tmp_path / "out"
+        json_files = list(out_dir.glob("*.json"))
+        assert len(json_files) == 1
+        with open(json_files[0]) as f:
+            data = json.load(f)
+        assert data["mode"] == "engram"
+        assert data["mean_restore_latency_s"] is not None
+
+    def test_no_network_calls_in_dry_run(self, tmp_path, monkeypatch):
+        """Confirm dry-run doesn't touch urllib."""
+        import urllib.request
+
+        def _fail(*_a, **_kw):
+            raise RuntimeError("Network call made in dry-run mode")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fail)
+        dataset_path = str(tmp_path / "dataset.json")
+        _write_dataset(dataset_path, [_make_sample("conv-1")])
+        main([
+            "--mode", "engram",
+            "--model", "test-model",
+            "--dataset-path", dataset_path,
+            "--conversations", "1",
+            "--output-dir", str(tmp_path / "out"),
+            "--dry-run",
+        ])


### PR DESCRIPTION
## Summary

Lands the **LoCoMo** harness as the first of four Tier 1 benchmarks under KHA-255. Pre-built locally so tomorrow's H200 / OVH session starts executing instead of building.

This is **part 1 of 4**. Each remaining Tier 1 benchmark gets its own focused PR rather than a single mega-bundle, so each can be validated independently on the H200 and shipped on its own cadence:

1. **LoCoMo** — this PR
2. LongMemEval — follow-up PR
3. RULER — follow-up PR
4. GraphWalks — follow-up PR

Leaderboard submission target: **CS-100 (The Gauntlet)**.

## What's included

- `scripts/benchmarks/locomo_runner.py` — stateless baseline + Engram (snapshot persistence) modes, official LoCoMo F1 scoring
- `tests/benchmarks/test_locomo_runner.py` — 37 unit tests, CPU-only, dry-run (no GPU required)
- `scripts/benchmarks/preflight_kha348.py` — verifies KHA-348 pending-restore registry fix is present in git history before a run
- `scripts/benchmarks/preflight_base.sh` — repo-sync + conflict-marker preflight
- `docs/benchmarks/locomo-spec-2026-05-03.md` — models in scope, success criteria, cost estimate
- `chore`: swap `aws` CLI to `s3cmd` for DigitalOcean Spaces compatibility on the result-upload path

## Methodology

Two-phase per benchmark: **stateless baseline** vs **Engram with snapshot persistence**. Matches the existing `compat-<model>-<date>.md` result-record convention established by prior Nemotron-3-Super H200 runs (2026-04-01 / 2026-04-02).

## Models in scope

- **Primary:** Nemotron-3-Super-120B-A12B-FP8 (already validated in Engram Phase 10 at 96.4%; 5.3 GB snapshot)
- **Fallbacks:** Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16 (gates CAI-8 humanoid demo), NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16 (CS-86 OVH always-on demo)

## Validation

- CPU-only unit tests: 37 passing locally (dry-run mode)
- GPU smoke run: **deferred** — runs on H200 tomorrow before any merge
- **Do not merge until the OVH/H200 smoke run validates the harness end-to-end.**

## Test plan

- [ ] OVH/H200 smoke run completes end-to-end against Nemotron-3-Super
- [ ] F1 scores recorded in `compat-*` format
- [ ] No regressions in stateless baseline path
- [ ] `preflight_kha348.py` confirms registry fix present before each run

## Related

- KHA-255 — parent ticket (part 1 of 4)
- KHA-348 — pending-restore registry fix (preflight dependency)
- CS-100 — leaderboard submission target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LoCoMo benchmark framework for Engram validation with stateless and engram evaluation modes.
  * Added preflight validation checks to ensure system readiness before benchmark execution.

* **Documentation**
  * Added comprehensive LoCoMo benchmark specification defining goals, success criteria, and test configurations.

* **Tests**
  * Added comprehensive test suite covering benchmark functionality, argument parsing, dataset loading, and scoring logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->