### PR TITLE
docs(port-plan): add §6 rtk-safe verification protocol (ban git log)

### DIFF
--- a/docs/upstream-sync/scheduler-decomposition-port.md
+++ b/docs/upstream-sync/scheduler-decomposition-port.md
@@ -135,12 +135,37 @@ The per-commit structure of Phases A–F enables clean rollback if a later phase
 
 After each Phase (A, B, C, D, E, F) lands, post a status comment on the port PR with:
 
-- Commits landed in the phase (SHA + one-line subject each)
+- Commits landed in the phase (SHA + one-line subject each, captured via `git rev-parse` per the verification protocol below)
 - Any deviations from this plan
 - Open questions resolved during execution + how
 - Block balance after the phase
 
 Enables overseer review without re-reading the full diff at each checkpoint.
+
+### Verification protocol (rtk-safe)
+
+`rtk` (the token-optimized CLI proxy active in this environment) caches porcelain `git log` output and can serve a STALE SHA for HEAD. Plumbing commands pass through raw (diagnostic-confirmed 2026-05-20). Therefore:
+
+**HARD RULE: `git log` is BANNED for any verification or decision-gating check during the port.** "Prefer plumbing" relies on remembering every time — across 13–16 commits and six phases, that's a slip waiting to happen. State inspection uses plumbing ONLY:
+
+| Need | Use |
+|---|---|
+| Current HEAD | `git rev-parse HEAD` |
+| Confirm a commit's contents | `git cat-file -p HEAD` (or `-p <sha>`) |
+| Current branch ref | `git symbolic-ref HEAD` |
+| Tag / ref resolution | `git show-ref --tags` ; `git rev-parse <ref>` |
+| Commit count in a range | `git rev-list --count <range>` |
+| File contents at a ref | `git show <ref>:<path>` |
+
+For human-readable history ONLY (never to gate a decision): `rtk proxy git log ...` bypasses the cache.
+
+**Per-phase backstop (memory-independent):**
+
+- At each phase boundary, capture HEAD via `git rev-parse HEAD`. Record the SHA in the PR comment AND `s3://engram/coordination/SESSION_STATE.md`.
+- Before the next phase starts, re-confirm `git rev-parse HEAD` equals the last recorded SHA. Mismatch = STOP and escalate (real divergence in the worktree, not a display artifact).
+- Block-balance checks use `grep` on files directly (not `git`) — unaffected by rtk, keep as-is.
+
+This protocol is not optional. The rtk caching issue is tracked separately as an out-of-band tooling bug; for the port window we work around it with this discipline.
 
 ## 7. Resolved decisions and remaining open questions
 

--- a/docs/upstream-sync/scheduler-decomposition-port.md
+++ b/docs/upstream-sync/scheduler-decomposition-port.md
@@ -135,7 +135,7 @@ The per-commit structure of Phases A–F enables clean rollback if a later phase
 
 After each Phase (A, B, C, D, E, F) lands, post a status comment on the port PR with:
 
-- Commits landed in the phase (SHA + one-line subject each, captured via `git rev-parse` per the verification protocol below)
+- Commits landed in the phase (SHA via `git rev-parse HEAD` + one-line subject via `git show -s --format=%s <sha>`; per the verification protocol below)
 - Any deviations from this plan
 - Open questions resolved during execution + how
 - Block balance after the phase


### PR DESCRIPTION
## Summary

Amends [`docs/upstream-sync/scheduler-decomposition-port.md`](../blob/docs/port-plan-rtk-safe-verification-protocol/docs/upstream-sync/scheduler-decomposition-port.md) §6 with a rtk-safe verification protocol that must be followed during the scheduler decomposition port (13–16 commits, six phases).

## Background

During the v0.5.0 release tagging on 2026-05-20, porcelain `git log` returned a different SHA for HEAD than plumbing (`git rev-parse`, `git cat-file`). The diagnostic isolated the cause to the `rtk` token-optimized CLI proxy intercepting and caching `git log` output. Plumbing commands passed through raw. The v0.5.0 tag was verified safe via plumbing; no impact on the merge or the release artifact.

But across 13–16 commits and six phases, a stale-HEAD verification slip via `git log` could cause the agent to commit to the wrong worktree, tag the wrong commit, or believe a phase landed when it didn't. "Prefer plumbing" relies on memory; the port needs a hard ban plus a memory-independent backstop.

## What changes

§6 grows a new subsection **"Verification protocol (rtk-safe)"** containing:

1. **Hard ban on `git log` for verification or decision-gating** during the port. `rtk proxy git log ...` reserved for human-readable history only.
2. **Plumbing-only command table** covering: current HEAD, commit contents, branch ref, tag resolution, commit count, file-at-ref.
3. **Per-phase memory-independent backstop:** record HEAD via `git rev-parse HEAD` at every phase boundary into PR comment + `s3://engram/coordination/SESSION_STATE.md`; re-confirm before the next phase starts; mismatch = STOP and escalate.
4. **Block-balance checks** explicitly noted as `grep`-based (unaffected by rtk), no change.

Progress-checkpoint subsection §6 also got a one-line tweak: phase SHAs are captured "via `git rev-parse` per the verification protocol below" to make the cross-reference explicit.

The rtk caching issue itself is filed as a separate out-of-band tooling bug; this PR is the port-window mitigation.

## Test plan

- [ ] Reviewer reads the new §6 subsection end-to-end
- [ ] Confirm the plumbing command table covers every state-inspection need that comes up during a typical port phase
- [ ] Confirm the per-phase backstop is implementable without additional tooling (SESSION_STATE.md location, PR comment format)
- [ ] Doc-only PR; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded scheduler decomposition port guide with concrete per-phase progress checkpoints.
  * Added a stricter verification protocol: explicit allowed verification steps and a per-phase backstop requiring snapshot capture and mismatch detection before advancing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->