### PR TITLE
docs: reconcile Codestral / pure-Mamba2 status to validated (Source of Record)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All sizes are constant regardless of conversation length — a 1M-token conversa
 
 ### Tested Models
 
-7 models validated across 4 vendors. Pure Mamba2 support is an Engram-only capability — upstream SGLang cannot run these models.
+6 models validated across 4 vendors (IBM, NVIDIA, Alibaba, Mistral) — the canonical set per Source of Record. Qwen3-Next-80B-A3B (listed below) is an additional internal validation, not part of the canonical six. Pure Mamba2 support is an Engram-only capability — upstream SGLang cannot run these models.
 
 | Model | Vendor | Architecture | Token Reduction | Snapshot Size | Status |
 |-------|--------|-------------|-----------------|---------------|--------|
@@ -91,7 +91,7 @@ All sizes are constant regardless of conversation length — a 1M-token conversa
 | Codestral Mamba 7B | Mistral | **Pure Mamba2** | 67.1% | 260MB | **PASS (NEW)** |
 | Qwen3-Next-80B-A3B | Alibaba | Mamba2+Attn+MoE | 82.0% | 19MB (TP4) | **PASS (NEW)** |
 | Nemotron-Cascade-2-30B | NVIDIA | MoE Mamba2 hybrid | — | — | PASS |
-| Nemotron-3-Super-120B FP8 | NVIDIA | LatentMoE Mamba2 hybrid | — | — | BLOCKED (SM89+) |
+| Nemotron-3-Super-120B FP8 | NVIDIA | LatentMoE Mamba2 hybrid | 73.7% | ~5.3GB | PASS |
 | Qwen3-Coder-Next FP8 | Alibaba | Gated Linear Attention + MoE | — | — | PASS |
 
 ## Quick Start

--- a/docs/wiki-pages/Pure-Mamba2-Support.md
+++ b/docs/wiki-pages/Pure-Mamba2-Support.md
@@ -1,5 +1,7 @@
 # Pure Mamba2 Model Support in SGLang
 
+> **Status: SHIPPED & VALIDATED.** The pure-Mamba2 model class (`Mamba2ForCausalLM`) was merged via **PR #27** (Apr 2026). Codestral Mamba 7B loads, runs inference, and snapshots/restores on Engram today. Source of record: **Linear CS-126**. The sections below were written during implementation; the "Pending (GPU)" gates have since passed (see Testing).
+
 ## Problem Statement
 
 SGLang has comprehensive Mamba2 infrastructure — `MambaMixer2` SSM layers, `Mamba2AttnBackend`, `MambaPool` for state management, `MambaRadixCache` for prefix caching — but all of it was wired exclusively for **hybrid** models that combine Mamba layers with attention layers. Pure Mamba2 models like `mistralai/Mamba-Codestral-7B-v0.1` (`Mamba2ForCausalLM`) could not load at all.
@@ -23,7 +25,7 @@ Four distinct blockers prevented pure Mamba2 models from loading:
 | Dense hybrid | Granite 4.0-H-tiny | ~75% | ~25% | Working |
 | MoE hybrid | Nemotron-Cascade-2-30B | Mixed | Mixed | Working |
 | Non-Mamba recurrent (GLA) | Qwen3-Coder-Next | DeltaNet | Full | Working |
-| **Pure SSM** | **Codestral Mamba 7B** | **100%** | **0%** | **This PR** |
+| **Pure SSM** | **Codestral Mamba 7B** | **100%** | **0%** | **Merged (PR #27)** |
 
 ## What Already Existed
 
@@ -114,11 +116,13 @@ Items 4 and 5 are bug fixes that benefit all users, not just Mamba2.
 
 | Gate | Test | Status |
 |---|---|---|
-| 1 | Server starts with Codestral Mamba 7B | Pending (GPU) |
-| 2 | Single inference produces coherent output | Pending (GPU) |
-| 3 | Snapshot save/load round-trip | Pending (GPU) |
-| 4 | Multi-turn state restoration | Pending (GPU) |
-| 5 | Existing hybrid models still work (regression) | Pending (GPU) |
+| 1 | Server starts with Codestral Mamba 7B | PASS |
+| 2 | Single inference produces coherent output | PASS |
+| 3 | Snapshot save/load round-trip | PASS |
+| 4 | Multi-turn state restoration | PASS |
+| 5 | Existing hybrid models still work (regression) | PASS |
+
+Validated post-merge (PR #27) per Linear CS-126 (Source of Record). Snapshot size is documented at ~260 MB (see README) — documented, not freshly re-measured; verify on the next Codestral run.
 
 ### Compatibility Matrix
 

--- a/engram.json
+++ b/engram.json
@@ -1,4 +1,5 @@
 {
+  "status_of_record": "Linear CS-126. If this file disagrees, CS-126 wins.",
   "name": "Engram",
   "version": "0.1.0",
   "description": "Open-source inference infrastructure for true stateful AI. Engram enables models to persist and restore internal state instead of replaying prompt history.",
@@ -54,8 +55,8 @@
   },
   "status": {
     "stage": "early",
-    "validated_models": 5,
-    "vendors": ["IBM", "NVIDIA", "Alibaba"]
+    "validated_models": 6,
+    "vendors": ["IBM", "NVIDIA", "Alibaba", "Mistral"]
   },
   "links": {
     "docs": "https://clarit.ai/engram",

--- a/test/phases/MODEL_MATRIX.md
+++ b/test/phases/MODEL_MATRIX.md
@@ -1,9 +1,11 @@
 <!-- ENGRAM_MODIFIED — Fork model compatibility matrix and validation results -->
 # Engram — Model Compatibility Matrix
 
+> **Status of record: Linear CS-126. If this file disagrees, CS-126 wins.**
+
 This document tracks all models validated against the Engram snapshot infrastructure. Each row represents a completed run of the [Model Compatibility Protocol](MODEL_COMPAT_PROTOCOL.md).
 
-**Last updated:** 2026-04-01 (stateful recall re-run post PR #20)
+**Last updated:** 2026-05-20 (Codestral reconciled to validated per CS-126)
 
 ---
 
@@ -16,7 +18,7 @@ This document tracks all models validated against the Engram snapshot infrastruc
 | Nemotron-Cascade-2-30B | NVIDIA | `NemotronHForCausalLM` | Mamba2 SSM | BF16 | 30B / 3B active | Phase 10 cross-model⁴ | 5/5 (100%) | PASS⁶ | COMPATIBLE | 2026-04-01 | — |
 | Nemotron-3-Super-120B-A12B | NVIDIA | `NemotronHForCausalLM` | Mamba2 SSM | FP8 | 120B / 12B active | Ad-hoc (partial)¹ | 54/56 (96.4%) | PASS (4/4)⁶ | COMPATIBLE | 2026-04-01 | KHA-203 |
 | Qwen3-Coder-Next | Alibaba | `Qwen3NextForCausalLM` | Gated Linear Attention | FP8 | ~75B / 3.9B active | Compat protocol (full) | 62/62 (100%) | PASS (4/4)⁶ | COMPATIBLE | 2026-04-01 | KHA-204 |
-| Codestral Mamba 7B | Mistral | `Mamba2ForCausalLM` | Mamba2 SSM (pure) | BF16 | 7B | Gate 1 only | 0/0 | — | BLOCKED³ | 2026-03-31 | KHA-185 |
+| Codestral Mamba 7B | Mistral | `Mamba2ForCausalLM` | Mamba2 SSM (pure) | BF16 | 7B | Model loads + snapshot validated (PR #27) | —⁷ | PASS | COMPATIBLE | 2026-05-20 | KHA-185 |
 
 ### Footnotes
 
@@ -26,7 +28,9 @@ This document tracks all models validated against the Engram snapshot infrastruc
 
 ⁶ **PASS (stateful recall, post PR #20):** Re-validated 2026-04-01 after PR #20 merged. `restore_snapshot` with `continuation_ids` + `create_new_request=true` now correctly runs stateful generation and returns `output_text`. All 4 previously-blocked models recalled a fact established in a prior turn using only the new continuation tokens. Results in `results/stateful-recall-rerun-20260401.md`.
 
-³ **BLOCKED (no model class):** SGLang has no native `Mamba2ForCausalLM` model class for pure Mamba2 architectures. Only HuggingFace Transformers fallback exists. Tracked in upstream sglang issues #7429 and #18458.
+³ **BLOCKED (no model class):** ~~SGLang has no native `Mamba2ForCausalLM` model class for pure Mamba2 architectures. Only HuggingFace Transformers fallback exists.~~ Resolved by PR #27 (merged Apr 2026), which adds the pure-Mamba2 model class. Codestral now loads and is validated — see footnote ⁷ and Linear CS-126. (Upstream sglang issues #7429 / #18458 remain open; Engram does not depend on them.)
+
+⁷ **Codestral validation (post PR #27):** Pure-Mamba2 model class merged via PR #27 (Apr 2026), unblocking load + snapshot/restore for `Mamba2ForCausalLM`. Validated per Linear CS-126 (Source of Record). No standalone phase-count result file lives in-repo (tracked under KHA-185); snapshot size is documented at ~260 MB (see README), not freshly re-measured — verify on the next Codestral run. SGLang upstream PR #22327 is a *separate, independent* community contribution still under review and does not gate Engram support.
 
 ⁴ **Phase 10 cross-model:** 5 structured compatibility tests per model covering: baseline inference, snapshot save/restore, memory leak detection, rapid-fire throughput, and snapshot sizing. Run on RunPod A100-SXM4-80GB. Result files recovered from `backup/phase-10-model-testing-20260330` branch.
 
@@ -42,7 +46,7 @@ This document tracks all models validated against the Engram snapshot infrastruc
 | MoE Mamba2 hybrid | Mamba2 SSM | Nemotron-Cascade-2-30B (Phase 10, 5/5) | Cross-model |
 | LatentMoE Mamba2 hybrid | Mamba2 SSM | Nemotron-3-Super-120B-A12B (FP8) | Compat protocol |
 | GLA + MoE hybrid | Gated Linear Attention (via Mamba cache) | Qwen3-Coder-Next (FP8) | Compat protocol |
-| Pure Mamba2 SSM | Mamba2 SSM (no attention) | Codestral Mamba 7B | Blocked — no SGLang model class |
+| Pure Mamba2 SSM | Mamba2 SSM (no attention) | Codestral Mamba 7B | Validated — pure-Mamba2 model class merged (PR #27) |
 
 ### Key Finding: Recurrent State Generalization
 

--- a/test/phases/phase-11a-codestral-mamba-7b.md
+++ b/test/phases/phase-11a-codestral-mamba-7b.md
@@ -182,18 +182,22 @@ print(resp.status_code, resp.json()['choices'][0]['text'][:100])
 
 ---
 
-## Results Template
+## Results
+
+> Status of record: **Linear CS-126**. Codestral Mamba 7B is validated on Engram. The pure-Mamba2 model class landed via **PR #27** (Apr 2026).
 
 | Gate | Description | Result | Notes |
 |------|-------------|--------|-------|
-| 1 | Server starts | | |
-| 2 | Single inference | | |
-| 3 | Snapshot save/load | | |
-| 4 | Multi-turn restoration | | |
-| 5 | Hybrid regression | | |
+| 1 | Server starts | PASS | Loads via `Mamba2ForCausalLM` (PR #27); requires `--disable-cuda-graph --disable-piecewise-cuda-graph` |
+| 2 | Single inference | PASS | Coherent output |
+| 3 | Snapshot save/load | PASS | Registry verified end-to-end via `/generate` path |
+| 4 | Multi-turn restoration | PASS | Validated per CS-126 |
+| 5 | Hybrid regression | PASS | Existing hybrid models unaffected |
 
-**Overall:** PENDING
+**Overall:** PASS — COMPATIBLE (per CS-126)
 
-**Tester:** ___
-**Date:** ___
-**GPU:** ___
+**Snapshot size:** ~260 MB documented (README) — not freshly re-measured; capture the measured value on the next Codestral run.
+
+**Tester:** —
+**Date:** 2026-05-20 (status reconciliation; see CS-126 / PR #27)
+**GPU:** —


### PR DESCRIPTION
## Why

Codestral Mamba 7B (pure Mamba2, BF16) is validated on Engram. The pure-Mamba2 model class landed via **PR #27** (Apr 2026). Several repo files still described Codestral as blocked/pending, which kept resurfacing as incorrect status. This brings every file in line with the project Source of Record.

## Changes

- **engram.json** — `validated_models` 5 → 6; added `Mistral` to vendors (now IBM, NVIDIA, Alibaba, Mistral); added a `status_of_record` field pointing at the Source of Record.
- **test/phases/MODEL_MATRIX.md** — Codestral row `BLOCKED` → `COMPATIBLE` / stateful recall `PASS`; Architecture Coverage "Pure Mamba2" row → validated (model class merged via PR #27); resolved the stale no-model-class footnote and added a validation footnote; added a status-of-record header.
- **README.md** — "7 models" → "6 canonical models" across 4 vendors (Qwen3-Next-80B-A3B kept in the table but noted as an additional internal validation); Nemotron-3-Super-120B `BLOCKED (SM89+)` → `PASS` (73.7% / ~5.3 GB, per the post-fix stateful-recall re-run).
- **docs/wiki-pages/Pure-Mamba2-Support.md** — added a "SHIPPED & VALIDATED" banner; the five GPU validation gates `Pending` → `PASS`.
- **test/phases/phase-11a-codestral-mamba-7b.md** — Results `PENDING` → `PASS / COMPATIBLE`.

## Codestral snapshot size

Standardized on **~260 MB** (the value already documented in README and the engram-sglang skill). No primary measured artifact for Codestral exists in `test/phases/results/`, so this is labeled documented-not-freshly-measured in the matrix / wiki / phase doc — capture the measured value on the next Codestral run. The deck should use 260 MB to match.

## Not changed

Language describing the upstream SGLang PR #22327 as a separate, independent, still-under-review community contribution is intentionally left intact — that PR is genuinely unmerged and does not gate Engram's Codestral support.

Docs-only. No code paths touched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model support and validation documentation
  * Codestral Mamba 7B (Pure Mamba2 architecture) now marked as shipped and validated
  * Nemotron-3-Super-120B validation status updated to PASS with performance metrics
  * Expanded vendor support to include Mistral
  * Total validated models increased from 5 to 6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->