### PR TITLE
fix(snapshot): pass tensor (not Python int) to mamba_pool.free on restore error paths

### DIFF
--- a/python/sglang/srt/managers/scheduler_snapshot_handlers.py
+++ b/python/sglang/srt/managers/scheduler_snapshot_handlers.py
@@ -707,7 +707,7 @@ def handle_restore_snapshot(scheduler, recv_req):
             if metadata.fill_ids is None:
                 # Snapshot lacks fill_ids — incompatible; fabricating tokens would
                 # silently desync the token stream from the injected Mamba state.
-                mamba_pool.free(new_pool_idx_scalar)
+                mamba_pool.free(new_pool_idx)
                 return RestoreSnapshotReqOutput(
                     success=False,
                     message=(
@@ -727,7 +727,7 @@ def handle_restore_snapshot(scheduler, recv_req):
                 )
                 # Guard against context overflow before allocating
                 if len(origin_input_ids) >= scheduler.max_req_input_len:
-                    mamba_pool.free(new_pool_idx_scalar)
+                    mamba_pool.free(new_pool_idx)
                     return RestoreSnapshotReqOutput(
                         success=False,
                         message=(


### PR DESCRIPTION
## Summary

Hotfix for a pre-existing defect carved out of [PR #77](https://github.com/Clarit-AI/Engram/pull/77) (the scheduler-decomposition extraction).

`scheduler_snapshot_handlers.py:710` and `:730` — the two early-return branches in `handle_restore_snapshot` (fill_ids missing, context overflow) — pass a Python int (`new_pool_idx_scalar`, from `.item()`) to `mamba_pool.free()`. `MambaPool.free` takes a `torch.Tensor` and calls `.numel()` on it; an int raises AttributeError at runtime.

Pre-existing — originally at pre-extraction `scheduler.py:2070` and `:2090`. Carved out of #77 to keep the extraction PR purely semantics-preserving. This PR is the dedicated fix.

## Diff

Two single-line changes:

| Line | Before | After |
|---|---|---|
| `handlers.py:710` | `mamba_pool.free(new_pool_idx_scalar)` | `mamba_pool.free(new_pool_idx)` |
| `handlers.py:730` | `mamba_pool.free(new_pool_idx_scalar)` | `mamba_pool.free(new_pool_idx)` |

Other three `mamba_pool.free` call sites in the same file (L299, L801, L816) already pass the 1-d tensor correctly — the early-return branches were the inconsistent ones. After this fix, all five sites are consistent.

## Behavior change

The restore error paths now correctly release the allocated mamba_pool slot instead of crashing with AttributeError. Net effect is slot-leak avoidance under the failure modes:

- "snapshot lacks `fill_ids`" (L710 branch)
- "continuation_ids combined length ≥ `max_req_input_len`" (L730 branch)

## DRAFT — gating on targeted error-path GPU smoke

The happy-path snapshot save→restore→recall smoke that gated PR #77 does NOT exercise these branches. The required smoke construct either:

- **(a)** A restore with a deliberately broken snapshot lacking `fill_ids` — triggers the L710 branch. Construct: save a snapshot via the normal path, then mutate the on-disk metadata to remove the `fill_ids` key. Call `/restore_snapshot` against it. Expect `RestoreSnapshotReqOutput(success=False, message="Snapshot is incompatible: fill_ids missing. ...")` AND the allocated mamba_pool slot to be released (no slot leak in the post-restore pool stats).
- **(b)** A restore with `continuation_ids` whose combined length ≥ `max_req_input_len` — triggers the L730 branch. Construct: any valid snapshot + a `continuation_ids` list long enough to overflow when concatenated with `metadata.fill_ids`. Expect `RestoreSnapshotReqOutput(success=False, message="Input length ... meets or exceeds max_req_input_len ...")` AND the slot to be released.

Without this fix, both constructs hit AttributeError before the response can be sent.

Both probes are deterministic to construct without GPU intervention; they just need a running Engram with snapshot support.

## Validation

- `ruff check --select=F401,F821` (0.15.1): All checks passed
- `isort --check-only` (7.0.0): no diff
- `black --check` (26.1.0): 1 file left unchanged
- `python3 -m py_compile`: OK

Plumbing-verified branch base: `53da5ea1c3549fb17626243783231f6f5fb4f138` (post-#77-merge main). Branch HEAD: `9e262f6d0985d06dfa2d2d49cc86d4ae9f27c07b`.

## Test plan

- [ ] Reviewer reads the 2-line diff and confirms the fix matches the other 3 correct sites in the same function
- [ ] Targeted error-path GPU smoke (a) — broken snapshot lacking fill_ids — verify response + no slot leak (blocks ready-for-review)
- [ ] Targeted error-path GPU smoke (b) — context-overflow continuation_ids — verify response + no slot leak (blocks ready-for-review)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed resource cleanup issues during snapshot restoration when encountering incompatible snapshots or input length constraints, improving system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->