### PR TITLE
feat(bench): add TTFT and compute amortization metrics (KHA-394)

### DIFF
--- a/scripts/kha-394-ttft-amortization.py
+++ b/scripts/kha-394-ttft-amortization.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""KHA-394 TTFT and compute-amortization probe.
+
+The script expects an Engram server with snapshot persistence enabled. It keeps
+the metric intentionally narrow:
+
+1. Send a long-context chat request with streaming enabled and measure time to
+   the first generated token.
+2. Persist that conversation state as a snapshot.
+3. Restore the snapshot and generate one token with only a short continuation.
+   The restore endpoint is not streaming, so this is reported as
+   restore-plus-one-token latency rather than streaming TTFT.
+4. Estimate prefill work avoided over a multi-turn script by counting the long
+   context tokens that do not need to be replayed on each follow-up turn.
+
+Example:
+    python scripts/kha-394-ttft-amortization.py \
+      --server-url http://localhost:30000 \
+      --model ibm-granite/granite-4.0-h-tiny \
+      --target-words 50000 \
+      --turns 50 \
+      --active-params 4e9 \
+      --output-json test/phases/results/kha-394-h100-20260521.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+from transformers import AutoTokenizer
+
+DEFAULT_MODEL = "ibm-granite/granite-4.0-h-tiny"
+
+CONTEXT_PARAGRAPHS = [
+    (
+        "The Amazon River is the largest river by discharge volume of water in "
+        "the world. Its headwaters include high Andean tributaries in Peru, "
+        "and its basin spans a huge portion of South America."
+    ),
+    (
+        "The Great Barrier Reef is the world's largest coral reef system, "
+        "stretching for more than 2,300 kilometers off the coast of Queensland, "
+        "Australia, and supporting thousands of marine species."
+    ),
+    (
+        "Mount Everest is Earth's highest mountain above sea level. The "
+        "China-Nepal border crosses its summit, and its current official "
+        "elevation is 8,848.86 meters."
+    ),
+    (
+        "The International Space Station orbits Earth at roughly 420 kilometers "
+        "altitude and travels about 28,000 kilometers per hour, completing more "
+        "than fifteen orbits per day."
+    ),
+    (
+        "Jupiter is the largest planet in the Solar System. Its Great Red Spot "
+        "is a long-lived storm, and the planet's mass exceeds that of all other "
+        "planets combined by more than a factor of two."
+    ),
+]
+
+
+@dataclass
+class TokenWork:
+    context_tokens: int
+    continuation_tokens_per_turn: int
+    turns: int
+    stateless_prefill_tokens: int
+    engram_prefill_tokens: int
+    skipped_prefill_tokens: int
+    token_reduction_pct: float
+    assumed_active_params: float | None
+    estimated_flops_saved: float | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server-url", default="http://localhost:30000")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--target-words", type=int, default=50_000)
+    parser.add_argument("--turns", type=int, default=50)
+    parser.add_argument("--active-params", type=float, default=None)
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--request-timeout", type=float, default=900.0)
+    parser.add_argument("--conversation-id", default=None)
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def load_tokenizer(model: str):
+    return AutoTokenizer.from_pretrained(model)
+
+
+def build_context(target_words: int) -> str:
+    words: list[str] = []
+    idx = 0
+    while len(words) < target_words:
+        words.extend(CONTEXT_PARAGRAPHS[idx % len(CONTEXT_PARAGRAPHS)].split())
+        idx += 1
+    return " ".join(words[:target_words])
+
+
+def chat_messages(context: str) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a precise assistant. Read the reference material and "
+                "answer only the final instruction."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"{context}\n\n"
+                "Final instruction: reply with one short sentence confirming "
+                "that the reference text was processed."
+            ),
+        },
+    ]
+
+
+def encode_chat(tokenizer: Any, messages: list[dict[str, str]]) -> list[int]:
+    if hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template:
+        rendered = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        return tokenizer.encode(rendered, add_special_tokens=False)
+    rendered = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
+    return tokenizer.encode(rendered, add_special_tokens=False)
+
+
+def encode_continuation(tokenizer: Any, question: str) -> list[int]:
+    messages = [{"role": "user", "content": question}]
+    if hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template:
+        rendered = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        return tokenizer.encode(rendered, add_special_tokens=False)
+    return tokenizer.encode(question, add_special_tokens=False)
+
+
+def check_health(server_url: str) -> None:
+    response = requests.get(f"{server_url}/health", timeout=10)
+    response.raise_for_status()
+
+
+def stream_chat_ttft(
+    server_url: str,
+    model: str,
+    messages: list[dict[str, str]],
+    rid: str,
+    max_new_tokens: int,
+    timeout: float,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": max_new_tokens,
+        "stream": True,
+        "rid": rid,
+    }
+    start = time.perf_counter()
+    first_token_at: float | None = None
+    output_chunks: list[str] = []
+
+    with requests.post(
+        f"{server_url}/v1/chat/completions",
+        json=payload,
+        stream=True,
+        timeout=timeout,
+    ) as response:
+        response.raise_for_status()
+        for raw_line in response.iter_lines(decode_unicode=True):
+            if not raw_line or not raw_line.startswith("data: "):
+                continue
+            data = raw_line.removeprefix("data: ").strip()
+            if data == "[DONE]":
+                break
+            chunk = json.loads(data)
+            delta = chunk["choices"][0].get("delta", {})
+            text = delta.get("content") or ""
+            if text:
+                if first_token_at is None:
+                    first_token_at = time.perf_counter()
+                output_chunks.append(text)
+
+    end = time.perf_counter()
+    if first_token_at is None:
+        raise RuntimeError("stream completed without a content token")
+
+    return {
+        "ttft_ms": (first_token_at - start) * 1000,
+        "total_latency_ms": (end - start) * 1000,
+        "output_text": "".join(output_chunks),
+    }
+
+
+def save_snapshot(
+    server_url: str, conversation_id: str, timeout: float
+) -> dict[str, Any]:
+    last_body: dict[str, Any] | None = None
+    for _ in range(30):
+        start = time.perf_counter()
+        response = requests.post(
+            f"{server_url}/save_snapshot",
+            json={"conversation_id": conversation_id},
+            timeout=timeout,
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        response.raise_for_status()
+        body = response.json()
+        body["client_latency_ms"] = elapsed_ms
+        if body.get("success") is True:
+            return body
+        last_body = body
+        time.sleep(1)
+    raise RuntimeError(f"snapshot save did not succeed: {last_body}")
+
+
+def restore_one_token(
+    server_url: str,
+    conversation_id: str,
+    continuation_ids: list[int],
+    timeout: float,
+) -> dict[str, Any]:
+    start = time.perf_counter()
+    response = requests.post(
+        f"{server_url}/restore_snapshot",
+        json={
+            "conversation_id": conversation_id,
+            "create_new_request": True,
+            "continuation_ids": continuation_ids,
+            "max_new_tokens": 1,
+        },
+        timeout=timeout,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    response.raise_for_status()
+    body = response.json()
+    if body.get("success") is not True:
+        raise RuntimeError(f"restore-and-generate failed: {body}")
+    body["restore_plus_one_token_ms"] = elapsed_ms
+    return body
+
+
+def compute_token_work(
+    context_tokens: int,
+    continuation_tokens: int,
+    turns: int,
+    active_params: float | None,
+) -> TokenWork:
+    # Stateless clients replay the full long context for every follow-up turn.
+    # Engram restores the long-context state once and only prefills the short
+    # continuation. The first long-context request is common to both paths.
+    followup_turns = max(turns - 1, 0)
+    stateless = context_tokens + followup_turns * (context_tokens + continuation_tokens)
+    engram = context_tokens + followup_turns * continuation_tokens
+    skipped = stateless - engram
+    reduction = (skipped / stateless * 100) if stateless else 0.0
+    flops = None
+    if active_params is not None:
+        # Decoder-only inference is commonly approximated as 2 * active
+        # parameters per prefill token. This is a buyer-facing estimate, not a
+        # profiler trace.
+        flops = 2 * active_params * skipped
+    return TokenWork(
+        context_tokens=context_tokens,
+        continuation_tokens_per_turn=continuation_tokens,
+        turns=turns,
+        stateless_prefill_tokens=stateless,
+        engram_prefill_tokens=engram,
+        skipped_prefill_tokens=skipped,
+        token_reduction_pct=reduction,
+        assumed_active_params=active_params,
+        estimated_flops_saved=flops,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    tokenizer = load_tokenizer(args.model)
+    context = build_context(args.target_words)
+    messages = chat_messages(context)
+    prompt_ids = encode_chat(tokenizer, messages)
+    continuation_question = "Give a one-word acknowledgement of the restored context."
+    continuation_ids = encode_continuation(tokenizer, continuation_question)
+    token_work = compute_token_work(
+        len(prompt_ids), len(continuation_ids), args.turns, args.active_params
+    )
+
+    result: dict[str, Any] = {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "model": args.model,
+        "server_url": args.server_url,
+        "target_words": args.target_words,
+        "conversation_id": args.conversation_id or f"kha-394-{uuid.uuid4().hex[:10]}",
+        "methodology": {
+            "cold_ttft": "streaming /v1/chat/completions with the full long context",
+            "restore_latency": (
+                "/restore_snapshot create_new_request=true with max_new_tokens=1; "
+                "reported separately because restore_snapshot is not streaming"
+            ),
+            "flops_estimate": (
+                "2 * active_params * skipped_prefill_tokens when --active-params "
+                "is supplied"
+            ),
+        },
+        "token_work": asdict(token_work),
+    }
+
+    if args.dry_run:
+        result["dry_run"] = True
+    else:
+        check_health(args.server_url)
+        cold = stream_chat_ttft(
+            args.server_url,
+            args.model,
+            messages,
+            result["conversation_id"],
+            args.max_new_tokens,
+            args.request_timeout,
+        )
+        save = save_snapshot(
+            args.server_url, result["conversation_id"], args.request_timeout
+        )
+        restore = restore_one_token(
+            args.server_url,
+            result["conversation_id"],
+            continuation_ids,
+            args.request_timeout,
+        )
+        result["cold_long_context"] = cold
+        result["save_snapshot"] = save
+        result["restore_generate"] = restore
+        result["speedup_vs_cold_ttft"] = (
+            cold["ttft_ms"] / restore["restore_plus_one_token_ms"]
+            if restore["restore_plus_one_token_ms"]
+            else math.inf
+        )
+
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kha-394-ttft-amortization.py
+++ b/scripts/kha-394-ttft-amortization.py
@@ -189,8 +189,14 @@ def stream_chat_ttft(
             if data == "[DONE]":
                 break
             chunk = json.loads(data)
-            delta = chunk["choices"][0].get("delta", {})
-            text = delta.get("content") or ""
+            # Check for error or non-token events
+            if "error" in chunk:
+                continue
+            choices = chunk.get("choices")
+            if not choices or not isinstance(choices, list) or len(choices) == 0:
+                continue
+            delta = choices[0].get("delta", {})
+            text = delta.get("content", "")
             if text:
                 if first_token_at is None:
                     first_token_at = time.perf_counter()
@@ -213,18 +219,26 @@ def save_snapshot(
     last_body: dict[str, Any] | None = None
     for _ in range(30):
         start = time.perf_counter()
-        response = requests.post(
-            f"{server_url}/save_snapshot",
-            json={"conversation_id": conversation_id},
-            timeout=timeout,
-        )
-        elapsed_ms = (time.perf_counter() - start) * 1000
-        response.raise_for_status()
-        body = response.json()
-        body["client_latency_ms"] = elapsed_ms
-        if body.get("success") is True:
-            return body
-        last_body = body
+        try:
+            response = requests.post(
+                f"{server_url}/save_snapshot",
+                json={"conversation_id": conversation_id},
+                timeout=timeout,
+            )
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            response.raise_for_status()
+            body = response.json()
+            body["client_latency_ms"] = elapsed_ms
+            if body.get("success") is True:
+                return body
+            last_body = body
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            last_body = {
+                "success": False,
+                "error": str(e),
+                "client_latency_ms": elapsed_ms,
+            }
         time.sleep(1)
     raise RuntimeError(f"snapshot save did not succeed: {last_body}")
 

--- a/test/phases/results/INDEX.md
+++ b/test/phases/results/INDEX.md
@@ -28,6 +28,7 @@ All results for the Engram snapshot persistence testing program. Each phase buil
 | compat | Nemotron-3-Super-120B-A12B FP8 | **PASS** (54/56, 96.4%) | NemotronHForCausalLM | 2026-04-01 |
 | compat | Qwen3-Coder-Next FP8 (ad-hoc) | **PASS** (56/59) | Qwen3NextForCausalLM | 2026-04-01 |
 | compat | Qwen3-Coder-Next FP8 (protocol) | **PASS** (62/62, 100%) | Qwen3NextForCausalLM | 2026-04-01 |
+| KHA-394 | TTFT + compute amortization | **PASS** (7.43x restore-vs-cold TTFT, 97.94% token-work reduction) | granite-4.0-h-tiny | 2026-05-21 |
 
 ---
 
@@ -180,6 +181,11 @@ New models validated using the [Model Compatibility Protocol](../MODEL_COMPAT_PR
 
 48-layer GLA + MoE hybrid, FP8 via HF-native block quantization. Key finding: GLA recurrent state routes through Mamba cache — snapshot infrastructure captures it with zero code changes. Requires `SGLANG_ENABLE_JIT_DEEPGEMM=0`. Zero model-specific failures under the protocol. Stateful recall BLOCKED (pre-existing restore API gap, all models).
 
+### KHA-394 - TTFT and Compute Amortization
+**Result**: PASS | **File**: `kha-394-h100-20260521.md`
+
+Measured a 50,000-word / 64,187-token Granite tiny prompt on a Google Cloud H100. Cold streaming TTFT was 3,027ms. Snapshot save succeeded from WARM tier in 259ms. Restore-and-generate with a short continuation and `max_new_tokens=1` completed in 408ms, a 7.43x improvement over cold TTFT. Across a modeled 50-turn script, Engram avoids 3,145,163 prefill tokens, reducing token work by 97.94%. With a 4.0B active-parameter assumption, this maps to an estimated 2.52e16 inference FLOPs avoided.
+
 ---
 
 ## Supporting Files
@@ -192,6 +198,7 @@ New models validated using the [Model Compatibility Protocol](../MODEL_COMPAT_PR
 | `../scripts/phase-10-h-small-test.py` | Granite-specific test script |
 | `../scripts/phase-10-resilience.py` | Resilience/adversarial test script |
 | `../scripts/phase-10-context-scaling.py` | 2K-128K context window scaling script |
+| `../../../scripts/kha-394-ttft-amortization.py` | KHA-394 TTFT and compute-amortization probe |
 | `../scripts/download-model.sh` | Model download helper |
 | `../config.sh` | Single source of truth for model paths, ports, dirs |
 | `../MODEL_COMPAT_PROTOCOL.md` | Standardized agent prompt for new model validation |

--- a/test/phases/results/kha-394-h100-20260521.json
+++ b/test/phases/results/kha-394-h100-20260521.json
@@ -1,0 +1,47 @@
+{
+  "created_at": "2026-05-21T08:25:30.842238+00:00",
+  "model": "ibm-granite/granite-4.0-h-tiny",
+  "server_url": "http://localhost:30003",
+  "target_words": 50000,
+  "conversation_id": "kha-394-4de0d9dedb",
+  "methodology": {
+    "cold_ttft": "streaming /v1/chat/completions with the full long context",
+    "restore_latency": "/restore_snapshot create_new_request=true with max_new_tokens=1; reported separately because restore_snapshot is not streaming",
+    "flops_estimate": "2 * active_params * skipped_prefill_tokens when --active-params is supplied"
+  },
+  "token_work": {
+    "context_tokens": 64187,
+    "continuation_tokens_per_turn": 41,
+    "turns": 50,
+    "stateless_prefill_tokens": 3211359,
+    "engram_prefill_tokens": 66196,
+    "skipped_prefill_tokens": 3145163,
+    "token_reduction_pct": 97.93869199924393,
+    "assumed_active_params": 4000000000.0,
+    "estimated_flops_saved": 2.5161304e+16
+  },
+  "cold_long_context": {
+    "ttft_ms": 3027.3135409952374,
+    "total_latency_ms": 3696.050591999665,
+    "output_text": "The reference text was processed."
+  },
+  "save_snapshot": {
+    "success": true,
+    "snapshot_id": "kha-394-4de0d9dedb-t0",
+    "message": "Snapshot saved successfully (from WARM tier)",
+    "client_latency_ms": 258.8723160006339
+  },
+  "restore_generate": {
+    "success": true,
+    "rid": "restored-b12ac02d",
+    "mamba_pool_idx": null,
+    "message": null,
+    "token_count": null,
+    "output_ids": [
+      474
+    ],
+    "output_text": "ack",
+    "restore_plus_one_token_ms": 407.6769920065999
+  },
+  "speedup_vs_cold_ttft": 7.425765006003155
+}

--- a/test/phases/results/kha-394-h100-20260521.md
+++ b/test/phases/results/kha-394-h100-20260521.md
@@ -1,0 +1,77 @@
+# KHA-394: TTFT and Compute-Amortization Metrics
+
+**Date**: 2026-05-21
+**GPU**: Google Cloud H100 80GB
+**Model**: `ibm-granite/granite-4.0-h-tiny`
+**Server**: `--enable-snapshot-persistence --snapshot-trigger-policy every_turn --mem-fraction-static 0.80 --disable-cuda-graph`
+**Script**: `scripts/kha-394-ttft-amortization.py`
+**Raw result**: `test/phases/results/kha-394-h100-20260521.json`
+
+---
+
+## Summary
+
+KHA-394 adds a reproducible metric path for buyer-facing latency and cost
+translation:
+
+- cold long-context streaming TTFT for a 50,000-word prompt
+- restore-and-generate latency after an Engram snapshot restore
+- prefill tokens avoided across a 50-turn script
+- estimated inference FLOPs avoided using `2 * active_params * skipped_prefill_tokens`
+
+The restore endpoint is not streaming, so the restore metric is reported as
+`restore_plus_one_token_ms` rather than streaming TTFT.
+
+---
+
+## Result
+
+| Metric | Value |
+|--------|------:|
+| Target context | 50,000 words |
+| Prompt tokens | 64,187 |
+| Cold long-context TTFT | 3,027 ms |
+| Cold request total latency | 3,696 ms |
+| Snapshot save latency | 259 ms |
+| Restore + one generated token | 408 ms |
+| Speedup vs cold TTFT | 7.43x |
+| Turns modeled | 50 |
+| Stateless prefill tokens | 3,211,359 |
+| Engram prefill tokens | 66,196 |
+| Skipped prefill tokens | 3,145,163 |
+| Token-work reduction | 97.94% |
+| Assumed active parameters | 4.0B |
+| Estimated inference FLOPs saved | 2.52e16 |
+
+---
+
+## Methodology
+
+1. Build a deterministic 50,000-word reference prompt.
+2. Count prompt and continuation tokens with the model tokenizer.
+3. Send the long-context request through streaming `/v1/chat/completions` and
+   measure client-side time to the first non-empty content delta.
+4. Save the request's state through `/save_snapshot` using the durable
+   `conversation_id`.
+5. Restore with `/restore_snapshot` using `create_new_request=true`,
+   `continuation_ids`, and `max_new_tokens=1`.
+6. Model compute amortization over 50 turns:
+   - stateless path replays the long context on every follow-up turn
+   - Engram path restores long-context state and only prefills each short
+     continuation
+
+The FLOPs figure is an estimate for external-facing cost translation, not a
+profiler trace. It uses the common decoder-inference approximation
+`2 * active_params` per prefill token and the Granite tiny active-parameter
+assumption of 4.0B.
+
+---
+
+## Notes
+
+- Snapshot save succeeded from WARM tier.
+- Restore-and-generate succeeded and returned `ack` for the short continuation.
+- The server emitted the known post-forward snapshot hook warning for
+  `req_pool_idx=None` after restore completion. It did not block the measured
+  save/restore path in this run, but it remains relevant to adjacent snapshot
+  cleanup work.


### PR DESCRIPTION
## Summary

Adds the KHA-394 benchmark/reporting path for latency and compute-cost translation:

- `scripts/kha-394-ttft-amortization.py` measures cold long-context streaming TTFT, snapshot save, restore-and-generate latency, and modeled prefill work avoided across a multi-turn script.
- Records a Google Cloud H100 Granite tiny run for a 50,000-word / 64,187-token prompt.
- Updates the phase results index with the new buyer-facing TTFT and compute-amortization metrics.

## H100 Result

Model: `ibm-granite/granite-4.0-h-tiny`

- Cold long-context streaming TTFT: 3,027 ms
- Cold request total latency: 3,696 ms
- Snapshot save from WARM tier: 259 ms
- Restore + one generated token: 408 ms
- Restore-vs-cold-TTFT speedup: 7.43x
- 50-turn modeled token-work reduction: 97.94%
- Skipped prefill tokens: 3,145,163
- Estimated inference FLOPs saved at 4.0B active params: 2.52e16

Note: `/restore_snapshot` is not a streaming endpoint, so the restore metric is reported as restore-plus-one-token latency rather than streaming TTFT.

## Validation

- `python -m py_compile scripts/kha-394-ttft-amortization.py`
- `python scripts/kha-394-ttft-amortization.py --dry-run --target-words 100 --turns 3 --active-params 4e9 --output-json /tmp/kha-394-dry-run.json`
- H100 run: `python scripts/kha-394-ttft-amortization.py --server-url http://localhost:30003 --model ibm-granite/granite-4.0-h-tiny --target-words 50000 --turns 50 --active-params 4e9 --output-json test/phases/results/kha-394-h100-20260521.json`
- `git diff --check`

## Notes

The server emitted the known post-forward snapshot hook warning for `req_pool_idx=None` after restore completion. It did not block save/restore success in this run; the report calls this out as adjacent snapshot cleanup context.

Linear: KHA-394





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmarking tool to measure cold first-token latency, snapshot save/restore latency, and estimated compute amortization across multi-turn interactions; supports dry-run and JSON output.

* **Tests**
  * Added test results and a detailed report documenting methodology, measured TTFT/restore metrics, token-work reduction and estimated FLOPs savings on H100 hardware.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->