### PR TITLE
fix(runtime): propagate snapshot request identity (KHA-342)

### DIFF
--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -3,6 +3,7 @@ import atexit
 import json
 import multiprocessing
 import time
+import uuid
 import warnings
 from typing import Dict, List, Optional, Union
 
@@ -79,9 +80,15 @@ class RuntimeEndpoint(BaseBackend):
         return self.chat_template
 
     def cache_prefix(self, prefix_str: str):
+        rid = f"runtime-cache-prefix-{uuid.uuid4().hex}"
         res = http_request(
             self.base_url + "/generate",
-            json={"text": prefix_str, "sampling_params": {"max_new_tokens": 0}},
+            json={
+                "text": prefix_str,
+                "sampling_params": {"max_new_tokens": 0},
+                "rid": rid,
+                "conversation_id": rid,
+            },
             api_key=self.api_key,
             verify=self.verify,
         )
@@ -105,6 +112,7 @@ class RuntimeEndpoint(BaseBackend):
 
     def commit_lazy_operations(self, s: StreamExecutor):
         data = {"text": s.text_, "sampling_params": {"max_new_tokens": 0}}
+        self._add_runtime_identity(s, data)
         self._add_images(s, data)
         res = http_request(
             self.base_url + "/generate",
@@ -116,6 +124,7 @@ class RuntimeEndpoint(BaseBackend):
 
     def fill_image(self, s: StreamExecutor):
         data = {"text": s.text_, "sampling_params": {"max_new_tokens": 0}}
+        self._add_runtime_identity(s, data)
         self._add_images(s, data)
         res = http_request(
             self.base_url + "/generate",
@@ -171,6 +180,7 @@ class RuntimeEndpoint(BaseBackend):
                 **sampling_params.to_srt_kwargs(),
             },
         }
+        self._add_runtime_identity(s, data)
 
         for item in [
             "return_logprob",
@@ -211,6 +221,7 @@ class RuntimeEndpoint(BaseBackend):
                 **sampling_params.to_srt_kwargs(),
             },
         }
+        self._add_runtime_identity(s, data)
 
         for item in [
             "return_logprob",
@@ -325,6 +336,7 @@ class RuntimeEndpoint(BaseBackend):
         self._assert_success(res)
 
     def _generate_http_request(self, s: StreamExecutor, data):
+        self._add_runtime_identity(s, data)
         self._add_images(s, data)
         res = http_request(
             self.base_url + "/generate",
@@ -339,6 +351,10 @@ class RuntimeEndpoint(BaseBackend):
         if s.images_:
             assert len(s.images_) == 1, "Only support one image."
             data["image_data"] = s.images_[0][1]
+
+    def _add_runtime_identity(self, s: StreamExecutor, data):
+        data.setdefault("rid", s.sid)
+        data.setdefault("conversation_id", s.sid)
 
     # --- BEGIN ENGRAM: snapshot HTTP client methods ---
     def save_snapshot(

--- a/test/sglang/snapshot/test_runtime_endpoint_identity.py
+++ b/test/sglang/snapshot/test_runtime_endpoint_identity.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+from sglang.lang.interpreter import ProgramState
+
+
+class FakeResponse:
+    status_code = 200
+    text = "{}"
+
+    def __init__(self, body=None):
+        self.body = body or {"text": "ok", "meta_info": {}}
+
+    def json(self):
+        return self.body
+
+
+class FakeSamplingParams:
+    dtype = None
+    stop = ()
+    regex = None
+
+    def to_srt_kwargs(self):
+        return {"max_new_tokens": 1}
+
+
+class FakeStreamExecutor:
+    def __init__(self, sid="runtime-sid"):
+        self.sid = sid
+        self.text_ = "hello"
+        self.images_ = []
+        self.backend = None
+
+    def sync(self):
+        pass
+
+    def end(self):
+        pass
+
+
+def make_endpoint():
+    endpoint = RuntimeEndpoint.__new__(RuntimeEndpoint)
+    endpoint.base_url = "http://runtime.test"
+    endpoint.api_key = None
+    endpoint.verify = None
+    return endpoint
+
+
+def capture_generate_payloads(endpoint_call):
+    payloads = []
+
+    def fake_http_request(url, **kwargs):
+        if url.endswith("/generate"):
+            payloads.append(kwargs["json"])
+        return FakeResponse()
+
+    with patch("sglang.lang.backend.runtime_endpoint.http_request", fake_http_request):
+        endpoint_call()
+
+    return payloads
+
+
+def test_generate_payload_includes_runtime_identity():
+    endpoint = make_endpoint()
+    stream_executor = FakeStreamExecutor("state-123")
+
+    payloads = capture_generate_payloads(
+        lambda: endpoint.generate(stream_executor, FakeSamplingParams())
+    )
+
+    assert payloads[0]["rid"] == "state-123"
+    assert payloads[0]["conversation_id"] == "state-123"
+
+
+def test_generate_stream_payload_includes_runtime_identity():
+    endpoint = make_endpoint()
+    stream_executor = FakeStreamExecutor("state-456")
+
+    def fake_http_request(url, **kwargs):
+        class StreamingResponse(FakeResponse):
+            def iter_lines(self, decode_unicode=False):
+                yield b'data: {"text": "x", "meta_info": {}}'
+                yield b"data: [DONE]"
+
+        assert kwargs["json"]["rid"] == "state-456"
+        assert kwargs["json"]["conversation_id"] == "state-456"
+        assert kwargs["json"]["stream"] is True
+        return StreamingResponse()
+
+    with patch("sglang.lang.backend.runtime_endpoint.http_request", fake_http_request):
+        assert list(
+            endpoint.generate_stream(stream_executor, FakeSamplingParams())
+        ) == [("x", {})]
+
+
+def test_lazy_generate_paths_include_runtime_identity():
+    endpoint = make_endpoint()
+    stream_executor = FakeStreamExecutor("state-789")
+
+    commit_payloads = capture_generate_payloads(
+        lambda: endpoint.commit_lazy_operations(stream_executor)
+    )
+    fill_payloads = capture_generate_payloads(
+        lambda: endpoint.fill_image(stream_executor)
+    )
+    helper_payloads = capture_generate_payloads(
+        lambda: endpoint._generate_http_request(
+            stream_executor,
+            {"text": stream_executor.text_, "sampling_params": {"max_new_tokens": 0}},
+        )
+    )
+
+    for payload in commit_payloads + fill_payloads + helper_payloads:
+        assert payload["rid"] == "state-789"
+        assert payload["conversation_id"] == "state-789"
+
+
+def test_cache_prefix_uses_explicit_runtime_identity():
+    endpoint = make_endpoint()
+
+    payloads = capture_generate_payloads(lambda: endpoint.cache_prefix("prefix"))
+
+    assert payloads[0]["rid"].startswith("runtime-cache-prefix-")
+    assert payloads[0]["conversation_id"] == payloads[0]["rid"]
+
+
+def test_program_state_snapshot_uses_stream_executor_identity():
+    stream_executor = FakeStreamExecutor("state-snapshot")
+    backend = SimpleNamespace()
+    backend.save_snapshot = lambda **kwargs: kwargs
+    stream_executor.backend = backend
+    state = ProgramState(stream_executor)
+
+    result = state.save_snapshot(snapshot_id="snapshot-1")
+
+    assert result["rid"] == "state-snapshot"
+    assert result["conversation_id"] == "state-snapshot"


### PR DESCRIPTION
## Summary
- Propagates the frontend `StreamExecutor.sid` into every RuntimeEndpoint `/generate` payload as both `rid` and `conversation_id`.
- Covers `generate`, `generate_stream`, lazy commit/fill-image paths, select/logprob helper calls, and cache-prefix warmup requests.
- Adds focused tests proving RuntimeEndpoint payload identity propagation and `ProgramState.save_snapshot()` use the same session identity.

## Why
KHA-342 identified that the snapshot APIs depend on `rid`/`conversation_id`, but normal Python frontend `/generate` calls did not send either value. That meant a later `save_snapshot()` could not reliably find the live conversation state created by the Python client.

## Validation
- `PYTHONPATH=python python -m pytest test/sglang/snapshot/test_runtime_endpoint_identity.py -q`
- `python -m py_compile python/sglang/lang/backend/runtime_endpoint.py test/sglang/snapshot/test_runtime_endpoint_identity.py`
- `git diff --check`
- Live H100 RuntimeEndpoint smoke on `/workspace/models/granite-4.0-h-tiny` with `--enable-snapshot-persistence`: Python frontend generation produced `rid=c9ab59b9d1fd422580272a7be9b24c0d`; `ProgramState.save_snapshot()`, `list_snapshots()`, and `restore_snapshot(conversation_id=rid)` all succeeded against that same id.

## Notes
- This PR does not touch files currently modified by open PRs #82 or #83.
- During the live smoke, the known post-forward warmup warning `req_pool_idx=None` appeared once before the KHA-342 probe. The explicit RuntimeEndpoint save/list/restore path still passed.

Closes #79









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26311258770](https://github.com/Clarit-AI/Engram/actions/runs/26311258770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26311258868](https://github.com/Clarit-AI/Engram/actions/runs/26311258868)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->