### PR TITLE
fix(kha-390): wire restored Mamba SSM slot as chunk-scan initial_state on EXTEND

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -205,6 +205,15 @@ class Mamba2Metadata(ForwardMetadata):
         assert context_lens_tensor is not None
         # precompute flag to avoid device syncs later
         has_initial_states = context_lens_tensor > 0
+        # --- BEGIN ENGRAM KHA-390: include slots hydrated from /restore_snapshot ---
+        # A restored request has extend_prefix_lens==0 (no radix-cache token prefix),
+        # so context_lens_tensor > 0 is False even though the Mamba pool slot was
+        # populated by _maybe_hydrate_from_pending_restore.  OR in the restored mask
+        # so the chunk-scan receives the restored SSM state as initial_state.
+        restored_mask = getattr(forward_batch, "mamba_restored_state_mask", None)
+        if restored_mask is not None:
+            has_initial_states = has_initial_states | restored_mask[:num_prefills]
+        # --- END ENGRAM KHA-390 ---
         prep_initial_states = torch.any(has_initial_states[:num_prefills]).item()
 
         query_start_loc = forward_metadata.query_start_loc[: num_prefills + 1]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1291,6 +1291,7 @@ class Req(ReqDllmMixin):
         self.extend_logprob_start_len = 0
         self.inflight_middle_chunks = 0
         self.mamba_pool_idx = None
+        self.mamba_has_restored_state = False  # --- BEGIN ENGRAM KHA-390 ---
         self.mamba_ping_pong_track_buffer = None
         self.mamba_next_track_idx = None
         self.mamba_last_track_seqlen = None

--- a/python/sglang/srt/managers/scheduler_snapshot_handlers.py
+++ b/python/sglang/srt/managers/scheduler_snapshot_handlers.py
@@ -325,6 +325,9 @@ def _maybe_hydrate_from_pending_restore(scheduler, req) -> Optional[bool]:
         return False
 
     req.mamba_pool_idx = new_pool_idx_0d
+    # --- BEGIN ENGRAM KHA-390: mark slot as restored so prepare_mixed uses it as initial_state ---
+    req.mamba_has_restored_state = True
+    # --- END ENGRAM KHA-390 ---
     # Assign or reconcile conversation_id from the hydrated entry.
     # When the entry was matched via rid (not alias) and the request
     # already carries a different conversation_id, the entry's is

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -306,6 +306,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     mamba_cow_src_indices: Optional[torch.Tensor] = None
     mamba_cow_dst_indices: Optional[torch.Tensor] = None
     mamba_clear_indices: Optional[torch.Tensor] = None
+    # --- BEGIN ENGRAM KHA-390: per-extend-req flag for slots hydrated from restore ---
+    # Shape [num_prefills], True for requests whose Mamba pool slot was populated by
+    # _maybe_hydrate_from_pending_restore.  Used in prepare_mixed to OR into
+    # has_initial_states so the chunk-scan receives the restored state as initial_state.
+    mamba_restored_state_mask: Optional[torch.Tensor] = None
+    # --- END ENGRAM KHA-390 ---
 
     # Optional seq_lens on cpu
     seq_lens_cpu: Optional[torch.Tensor] = None
@@ -640,6 +646,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ret.extend_prefix_lens_cpu = extend_prefix_lens
             ret.extend_seq_lens_cpu = extend_seq_lens
             ret.extend_logprob_start_lens_cpu = extend_logprob_start_lens
+            # --- BEGIN ENGRAM KHA-390 ---
+            restored_flags = [
+                getattr(req, "mamba_has_restored_state", False) for req in batch.reqs
+            ]
+            if any(restored_flags):
+                ret.mamba_restored_state_mask = torch.tensor(
+                    restored_flags, dtype=torch.bool
+                ).to(device, non_blocking=True)
+            # --- END ENGRAM KHA-390 ---
 
         if model_runner.use_ngram_embedding:
             ret._init_ngram_embedding_info(batch, device)


### PR DESCRIPTION
## Summary

- **Root cause**: `prepare_mixed` computes `has_initial_states = extend_prefix_lens > 0`. A request restored via `/restore_snapshot` has no radix-cache token prefix, so `extend_prefix_lens == 0` → `has_initial_states = False` → the pool slot populated by `_maybe_hydrate_from_pending_restore` is silently ignored by both the causal-conv and chunk-scan kernels. All tamper conditions (none/zeros/gaussian) produce byte-identical output (KHA-390).
- **Fix**: 4-file, additions-only change that propagates a `mamba_has_restored_state` flag from successful hydration through `ForwardBatch.mamba_restored_state_mask` into `prepare_mixed`, where it is OR'd into `has_initial_states` before `prep_initial_states` is computed.
- **Scope guard**: flag is only `True` for the initial EXTEND of a hydrated-from-restore request; warm path, continuation_ids path, and non-restored prefill are unaffected.

## Files changed

| File | Change |
|---|---|
| `managers/schedule_batch.py` | `Req.__init__`: init `mamba_has_restored_state = False` |
| `managers/scheduler_snapshot_handlers.py` | `_maybe_hydrate_from_pending_restore`: set `req.mamba_has_restored_state = True` after slot injection |
| `model_executor/forward_batch_info.py` | Add `ForwardBatch.mamba_restored_state_mask` field; populate in extend block from `batch.reqs` |
| `layers/attention/mamba/mamba2_metadata.py` | `prepare_mixed`: OR `mamba_restored_state_mask` into `has_initial_states` before `prep_initial_states` |

## Test plan

- [ ] **CPU**: `py_compile` passes all 4 files ✅
- [ ] **GPU**: Run KHA-387 ablation script (`scripts/kha-387-ssm-ablation.sh`) — `none/zeros/gaussian` tamper conditions must produce distinct output
- [ ] **GPU**: Re-run `debug/kha-390-probe-codestral` instrumentation — temporal-state-sums must propagate to output (random_disk should no longer collapse to 34 at first decode)
- [ ] **GPU**: PR #89 regression test (`test/srt/snapshot/test_restore_consumption_ablation.py`) should flip from `xfail` to `xpass` or `pass`
- [ ] **GPU**: KHA-397 cold-cost re-run to see if KHA-398 gate changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26279442901](https://github.com/Clarit-AI/Engram/actions/runs/26279442901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->