### PR TITLE
fix(kha-390): wire restored Mamba SSM slot as chunk-scan initial_state on EXTEND

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -205,6 +205,15 @@ class Mamba2Metadata(ForwardMetadata):
         assert context_lens_tensor is not None
         # precompute flag to avoid device syncs later
         has_initial_states = context_lens_tensor > 0
+        # --- BEGIN ENGRAM KHA-390: include slots hydrated from /restore_snapshot ---
+        # A restored request has extend_prefix_lens==0 (no radix-cache token prefix),
+        # so context_lens_tensor > 0 is False even though the Mamba pool slot was
+        # populated by _maybe_hydrate_from_pending_restore.  OR in the restored mask
+        # so the chunk-scan receives the restored SSM state as initial_state.
+        restored_mask = getattr(forward_batch, "mamba_restored_state_mask", None)
+        if restored_mask is not None:
+            has_initial_states = has_initial_states | restored_mask[:num_prefills]
+        # --- END ENGRAM KHA-390 ---
         prep_initial_states = torch.any(has_initial_states[:num_prefills]).item()
 
         query_start_loc = forward_metadata.query_start_loc[: num_prefills + 1]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1291,6 +1291,7 @@ class Req(ReqDllmMixin):
         self.extend_logprob_start_len = 0
         self.inflight_middle_chunks = 0
         self.mamba_pool_idx = None
+        self.mamba_has_restored_state = False  # --- BEGIN ENGRAM KHA-390 ---
         self.mamba_ping_pong_track_buffer = None
         self.mamba_next_track_idx = None
         self.mamba_last_track_seqlen = None

--- a/python/sglang/srt/managers/scheduler_snapshot_handlers.py
+++ b/python/sglang/srt/managers/scheduler_snapshot_handlers.py
@@ -325,6 +325,9 @@ def _maybe_hydrate_from_pending_restore(scheduler, req) -> Optional[bool]:
         return False
 
     req.mamba_pool_idx = new_pool_idx_0d
+    # --- BEGIN ENGRAM KHA-390: mark slot as restored so prepare_mixed uses it as initial_state ---
+    req.mamba_has_restored_state = True
+    # --- END ENGRAM KHA-390 ---
     # Assign or reconcile conversation_id from the hydrated entry.
     # When the entry was matched via rid (not alias) and the request
     # already carries a different conversation_id, the entry's is

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -306,6 +306,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     mamba_cow_src_indices: Optional[torch.Tensor] = None
     mamba_cow_dst_indices: Optional[torch.Tensor] = None
     mamba_clear_indices: Optional[torch.Tensor] = None
+    # --- BEGIN ENGRAM KHA-390: per-extend-req flag for slots hydrated from restore ---
+    # Shape [num_prefills], True for requests whose Mamba pool slot was populated by
+    # _maybe_hydrate_from_pending_restore.  Used in prepare_mixed to OR into
+    # has_initial_states so the chunk-scan receives the restored state as initial_state.
+    mamba_restored_state_mask: Optional[torch.Tensor] = None
+    # --- END ENGRAM KHA-390 ---
 
     # Optional seq_lens on cpu
     seq_lens_cpu: Optional[torch.Tensor] = None
@@ -640,6 +646,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ret.extend_prefix_lens_cpu = extend_prefix_lens
             ret.extend_seq_lens_cpu = extend_seq_lens
             ret.extend_logprob_start_lens_cpu = extend_logprob_start_lens
+            # --- BEGIN ENGRAM KHA-390 ---
+            restored_flags = [
+                getattr(req, "mamba_has_restored_state", False) for req in batch.reqs
+            ]
+            if any(restored_flags):
+                ret.mamba_restored_state_mask = torch.tensor(
+                    restored_flags, dtype=torch.bool
+                ).to(device, non_blocking=True)
+            # --- END ENGRAM KHA-390 ---
 
         if model_runner.use_ngram_embedding:
             ret._init_ngram_embedding_info(batch, device)


### PR DESCRIPTION
## Summary

- **Root cause**: `prepare_mixed` computed `has_initial_states = extend_prefix_lens > 0`. A restored request has no radix-cache token prefix (`extend_prefix_lens == 0`), so this was always `False` even after `_maybe_hydrate_from_pending_restore` populated the pool slot — the chunk-scan kernel received `initial_states = None`.
- **Fix**: Set `req.mamba_has_restored_state = True` on successful hydration, propagate through `ForwardBatch` as `mamba_restored_state_mask`, and OR it into `has_initial_states` in `prepare_mixed` before `prep_initial_states` is computed.
- **Scope**: Only affects the initial EXTEND of a hydrated-from-restore request. Warm path, continuation_ids path, and normal non-restored prefill are unaffected.

## Files changed (+28 lines, 0 deletions)

| File | Change |
|------|--------|
| `schedule_batch.py` | `Req.__init__`: add `mamba_has_restored_state = False` flag |
| `scheduler_snapshot_handlers.py` | `_maybe_hydrate_from_pending_restore`: set flag to `True` after successful inject |
| `forward_batch_info.py` | `ForwardBatch`: add `mamba_restored_state_mask` field + populate in extend block |
| `mamba2_metadata.py` | `prepare_mixed`: OR restored mask into `has_initial_states` |

## Supersedes

This is a clean cherry-pick of commit `9b42f711` onto `main`, superseding PR #90 (which was based on `rehome/scheduler-decomposition` with no onward path to main). PR #90 can be closed as superseded.

## GPU validation required before merge

- [ ] KHA-387 ablation (`scripts/kha-387-ssm-ablation.sh`) — none/zeros/gaussian must produce distinct token-ID sequences
- [ ] Probe re-run with `KHA390_PROBE=1` — temporal-state-sums must propagate to output (random_disk no longer collapses from 1856→34 at first decode)
- [ ] PR #89 regression test (`test_restore_consumption_ablation.py`) — should flip from `xfail` to `xpass/pass`
- [ ] KHA-397/398 cold-cost re-run — confirm restore cold cost unchanged

## Test plan

- `py_compile` passes on all 4 files ✅
- Verified diff is identical to original commit (`4 files changed, 28 insertions(+)`) ✅
- Clean cherry-pick: zero conflicts onto `main` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26302368102](https://github.com/Clarit-AI/Engram/actions/runs/26302368102)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26318074566](https://github.com/Clarit-AI/Engram/actions/runs/26318074566)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Mamba model state management to correctly handle request restoration and retraction scenarios, including proper initialization tracking for restored requests, accurate state tracking masks in batch operations, and consistent state cleanup when requests are retracted, improving reliability of long-running inference workloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Clarit-AI/Engram/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->