### PR TITLE
feat(benchmark): scaffold GraphWalks harness (CPU/mock dry-run)

### DIFF
--- a/benchmark/graphwalks/README.md
+++ b/benchmark/graphwalks/README.md
@@ -1,0 +1,192 @@
+# GraphWalks Benchmark — Engram
+
+Multi-hop graph-traversal QA benchmark that measures whether Engram's
+snapshot/restore capability reduces compute versus a stateless baseline.
+
+---
+
+## Dataset
+
+| Field    | Value |
+|----------|-------|
+| HF repo  | [`openai/graphwalks`](https://huggingface.co/datasets/openai/graphwalks) |
+| Task     | Multi-hop graph traversal QA |
+| License  | MIT (OpenAI GraphWalks) |
+| Size     | ~50 MB (confirmed on first download) |
+| Format   | JSONL; fields: `question_id`, `graph_text`, `question`, `answer`, `num_hops`, `num_nodes` |
+
+Each example presents a textual description of a directed graph and asks the
+model to traverse it for N hops to identify a target node.  Ground-truth answers
+are exact node labels, so scoring is deterministic via `ExactMatchScorer`.
+
+---
+
+## Metrics
+
+| Metric | Formula | Unit |
+|---|---|---|
+| `token_reduction` | `1 - engram_input_tokens / baseline_input_tokens` | fraction [0, 1] |
+| `ttft_speedup` | `baseline_ttft_s / engram_ttft_s` | ratio (>1 = Engram faster) |
+| `compute_amortization` | `token_reduction` for warm results; 0 for cold | fraction [0, 1] |
+
+All three metrics are computed per-question and aggregated across the run, with
+separate warm/cold breakdowns.
+
+---
+
+## Run Commands
+
+### CPU dry-run (no GPU, no server — CI-safe)
+
+```bash
+# Run all dry-run tests
+pytest benchmark/graphwalks/test_dry_run.py -v
+
+# Generate synthetic dataset
+python -m benchmark.graphwalks.download --dry-run
+
+# Dry-run the full runner pipeline
+python -m benchmark.graphwalks.runner --dry-run --output /tmp/gw_dry_run.jsonl
+```
+
+### GPU run (H100, Elastic 30B BF16 single-GPU)
+
+```bash
+# 1. Download dataset
+python -m benchmark.graphwalks.download
+
+# 2. Start Engram inference server
+python -m sglang.launch_server \
+    --model-path elastic-30b-bf16 \
+    --snapshot-dir /mnt/snapshots/graphwalks \
+    --port 30000
+
+# 3. Run benchmark (both baseline and Engram phases)
+python -m benchmark.graphwalks.runner \
+    --model-url http://localhost:30000/v1 \
+    --model elastic-30b-bf16 \
+    --snapshot-dir /mnt/snapshots/graphwalks \
+    --output results/graphwalks/elastic30b_h100.jsonl \
+    --num-questions 1000 \
+    --mode both
+```
+
+### Cluster run (Qwen3-Coder-Next FP8, TP=4)
+
+```bash
+python -m benchmark.graphwalks.runner \
+    --model-url http://localhost:30000/v1 \
+    --model qwen3-coder-next-fp8 \
+    --snapshot-dir /mnt/snapshots/graphwalks \
+    --output results/graphwalks/qwen3_tp4.jsonl \
+    --num-questions 1000 \
+    --mode both
+```
+
+---
+
+## Expected Output Shape
+
+Results are written as JSONL.  The first line is the run-level summary header;
+subsequent lines are per-question records.
+
+**Summary header** (line 1):
+```json
+{
+  "benchmark": "graphwalks",
+  "model": "elastic-30b-bf16",
+  "timestamp": "2026-05-22T...",
+  "n_total": 1000,
+  "n_warm": 850,
+  "n_cold": 150,
+  "token_reduction": 0.82,
+  "ttft_speedup": 3.1,
+  "compute_amortization": 0.82,
+  "warm_token_reduction": 0.82,
+  "warm_ttft_speedup": 3.1,
+  "cold_token_reduction": 0.0,
+  "cold_ttft_speedup": 0.95,
+  "metrics_by_hop": {
+    "1": {"n": 200, "token_reduction": 0.83, "ttft_speedup": 3.2, ...},
+    "2": {"n": 300, "token_reduction": 0.81, "ttft_speedup": 3.0, ...},
+    "3": {"n": 500, "token_reduction": 0.82, "ttft_speedup": 3.1, ...}
+  }
+}
+```
+
+**Per-question record** (lines 2+):
+```json
+{
+  "question_id": "gw_001",
+  "graph_size": 20,
+  "num_hops": 3,
+  "restore_mode": "warm",
+  "baseline_ttft_s": 0.95,
+  "baseline_input_tokens": 412,
+  "baseline_output_tokens": 8,
+  "baseline_answer": "Node F",
+  "baseline_score": 1.0,
+  "engram_ttft_s": 0.31,
+  "engram_input_tokens": 74,
+  "engram_output_tokens": 8,
+  "engram_answer": "Node F",
+  "engram_score": 1.0,
+  "token_reduction": 0.82,
+  "ttft_speedup": 3.06,
+  "compute_amortization": 0.82
+}
+```
+
+---
+
+## Results Storage
+
+Upload completed result files to S3 (DigitalOcean Spaces, sfo3):
+
+```bash
+s3cmd put results/graphwalks/elastic30b_h100.jsonl \
+    s3://engram/benchmarks/graphwalks/elastic30b_h100.jsonl \
+    --acl-private
+```
+
+Base path: `s3://engram/benchmarks/graphwalks/`
+
+---
+
+## GPU Run Checklist
+
+- [ ] Engram server starts cleanly with `--snapshot-dir`
+- [ ] Baseline phase completes without errors
+- [ ] Engram cold phase creates snapshot files
+- [ ] Engram warm phase reads from snapshots (check logs for "warm" labels)
+- [ ] `token_reduction` > 0.7 for warm questions
+- [ ] `ttft_speedup` > 2.0 for warm questions
+- [ ] Results uploaded to `s3://engram/benchmarks/graphwalks/`
+
+---
+
+## Models
+
+| Model | Precision | HW | Notes |
+|---|---|---|---|
+| Elastic 30B | BF16 | Single H100 | Reference model |
+| Qwen3-Coder-Next | FP8 | 4× H100 (TP=4) | Cluster run |
+
+---
+
+## File Layout
+
+```
+benchmark/graphwalks/
+├── __init__.py
+├── download.py        # Dataset download + synthetic generation
+├── judge.py           # ExactMatchScorer, GPT4oJudge, MockJudge
+├── results.py         # QuestionResult, RunSummary dataclasses + JSONL I/O
+├── runner.py          # GraphWalksRunner + CLI entry point
+├── test_dry_run.py    # CPU/mock pytest suite
+├── data/
+│   └── graphwalks/
+│       ├── test_dry_run.jsonl   (synthetic, generated locally)
+│       └── graphwalks_test.jsonl (downloaded from HF)
+└── README.md
+```

--- a/benchmark/graphwalks/__init__.py
+++ b/benchmark/graphwalks/__init__.py
@@ -1,0 +1,1 @@
+# GraphWalks benchmark harness for Engram stateful SGLang fork.

--- a/benchmark/graphwalks/conftest.py
+++ b/benchmark/graphwalks/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for GraphWalks benchmark tests.
+
+Adds the repo root to sys.path so that ``import benchmark.graphwalks.*``
+works when pytest is invoked from within the benchmark/graphwalks/ directory
+or from the repo root.
+"""
+
+import sys
+from pathlib import Path
+
+# Repo root is three levels up: benchmark/graphwalks/conftest.py → repo root
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/benchmark/graphwalks/download.py
+++ b/benchmark/graphwalks/download.py
@@ -1,0 +1,238 @@
+"""Download or synthesise the GraphWalks dataset.
+
+Dataset
+-------
+- HuggingFace repo : ``openai/graphwalks``
+- Task             : Multi-hop graph-traversal QA
+- License          : MIT (OpenAI GraphWalks)
+- Estimated size   : ~50 MB (exact size confirmed on first download)
+- Save path        : ``<benchmark_dir>/data/graphwalks/``
+
+Usage
+-----
+# Download from HuggingFace (requires ``datasets`` or ``huggingface_hub``):
+python -m benchmark.graphwalks.download
+
+# Dry-run: generate 5 synthetic questions only (no network, no GPU):
+python -m benchmark.graphwalks.download --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import string
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Root of the benchmark package.
+_BENCHMARK_DIR = Path(__file__).parent
+_DATA_DIR = _BENCHMARK_DIR / "data" / "graphwalks"
+
+HF_REPO_ID = "openai/graphwalks"
+DRY_RUN_PATH = _DATA_DIR / "test_dry_run.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic question generator
+# ---------------------------------------------------------------------------
+
+
+def generate_synthetic_question(
+    num_nodes: int = 5,
+    num_hops: int = 3,
+    seed: int = 0,
+) -> Dict:
+    """Generate a synthetic path-graph question with a known answer.
+
+    The graph is a simple directed path: A → B → C → … where node names are
+    single uppercase letters.  The question asks "starting from node X,
+    following the path, which node do you reach after N hops?"
+
+    Parameters
+    ----------
+    num_nodes:
+        Total number of nodes in the path graph.  Must be > num_hops.
+    num_hops:
+        Number of hops the question asks about.
+    seed:
+        Random seed (used to vary start node offset for different questions).
+
+    Returns
+    -------
+    dict with keys: question_id, graph_text, question, answer, num_hops,
+    num_nodes.
+    """
+    if num_nodes <= num_hops:
+        raise ValueError(
+            f"num_nodes ({num_nodes}) must be greater than num_hops ({num_hops})"
+        )
+    if num_nodes > 26:
+        raise ValueError("num_nodes must be ≤ 26 for single-letter node names")
+
+    rng = random.Random(seed)
+    offset = rng.randint(0, num_nodes - num_hops - 1)
+
+    # Build a path graph of exactly num_nodes nodes starting from the offset.
+    all_letters = list(string.ascii_uppercase)
+    nodes = all_letters[offset: offset + num_nodes]
+
+    # Textual description
+    edges_desc = " -> ".join(nodes)
+    graph_text = (
+        f"Graph description:\n"
+        f"This graph is a directed path with {num_nodes} nodes.\n"
+        f"Edges: {edges_desc}\n"
+        f"Each node connects only to the next node in the sequence."
+    )
+
+    start_node = nodes[0]
+    answer_node = nodes[num_hops]
+    question = (
+        f"Starting from node {start_node}, following the directed edges, "
+        f"which node do you reach after exactly {num_hops} hop(s)?"
+    )
+
+    question_id = f"synthetic_{seed}_hops{num_hops}_nodes{num_nodes}"
+
+    return {
+        "question_id": question_id,
+        "graph_text": graph_text,
+        "question": question,
+        "answer": answer_node,
+        "num_hops": num_hops,
+        "num_nodes": num_nodes,
+    }
+
+
+def generate_dry_run_dataset(
+    n: int = 5,
+    output_path: Optional[Path] = None,
+) -> List[Dict]:
+    """Generate *n* synthetic questions and write them to *output_path* (JSONL).
+
+    Uses varying seeds and hop counts to produce a diverse mini-dataset.
+    """
+    output_path = output_path or DRY_RUN_PATH
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    records = []
+    hop_cycle = [1, 2, 3, 2, 1]
+    for i in range(n):
+        num_hops = hop_cycle[i % len(hop_cycle)]
+        record = generate_synthetic_question(num_nodes=6, num_hops=num_hops, seed=i)
+        records.append(record)
+
+    with output_path.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+    logger.info("Wrote %d synthetic questions to %s", n, output_path)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# HuggingFace download
+# ---------------------------------------------------------------------------
+
+
+def download_from_hf(output_dir: Optional[Path] = None) -> Path:
+    """Download the GraphWalks dataset from HuggingFace.
+
+    Tries ``datasets`` first (richer API), then falls back to
+    ``huggingface_hub.snapshot_download`` for raw files.
+
+    Returns the local directory containing the dataset files.
+    """
+    output_dir = output_dir or _DATA_DIR
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Try datasets library first.
+    try:
+        from datasets import load_dataset  # noqa: PLC0415
+
+        logger.info("Downloading %s via `datasets` library…", HF_REPO_ID)
+        ds = load_dataset(HF_REPO_ID, split="test")
+
+        out_path = output_dir / "graphwalks_test.jsonl"
+        with out_path.open("w", encoding="utf-8") as fh:
+            for row in ds:
+                fh.write(json.dumps(row) + "\n")
+
+        logger.info("Saved %d rows to %s", len(ds), out_path)
+        return output_dir
+
+    except ImportError:
+        logger.info(
+            "`datasets` not available; falling back to huggingface_hub snapshot."
+        )
+
+    # Fallback: huggingface_hub.
+    try:
+        from huggingface_hub import snapshot_download  # noqa: PLC0415
+
+        local_dir = snapshot_download(
+            repo_id=HF_REPO_ID,
+            repo_type="dataset",
+            local_dir=str(output_dir / "hf_snapshot"),
+        )
+        logger.info("Snapshot downloaded to %s", local_dir)
+        return Path(local_dir)
+
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            f"Failed to download {HF_REPO_ID} from HuggingFace. "
+            "If you are offline, use --dry-run to generate synthetic data.\n"
+            f"Underlying error: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Download or synthesise the GraphWalks dataset.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate 5 synthetic questions instead of downloading from HF.",
+    )
+    p.add_argument(
+        "--n-synthetic",
+        type=int,
+        default=5,
+        help="Number of synthetic questions to generate in dry-run mode.",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory to save downloaded data (default: benchmark/data/graphwalks/).",
+    )
+    return p
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir) if args.output_dir else None
+
+    if args.dry_run:
+        path = (out_dir / "test_dry_run.jsonl") if out_dir else DRY_RUN_PATH
+        generate_dry_run_dataset(n=args.n_synthetic, output_path=path)
+    else:
+        download_from_hf(output_dir=out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/graphwalks/download.py
+++ b/benchmark/graphwalks/download.py
@@ -103,7 +103,7 @@ def generate_synthetic_question(
         "question_id": question_id,
         "graph_text": graph_text,
         "question": question,
-        "answer": answer_node,
+        "answer": [answer_node],
         "num_hops": num_hops,
         "num_nodes": num_nodes,
     }

--- a/benchmark/graphwalks/judge.py
+++ b/benchmark/graphwalks/judge.py
@@ -1,0 +1,104 @@
+"""Scoring / judging for GraphWalks benchmark.
+
+GraphWalks has exact ground-truth answers (node names along a path), so
+``ExactMatchScorer`` is the primary judge.  ``GPT4oJudge`` is available for
+borderline or free-form cases.  ``MockJudge`` is used in dry-run / CI contexts
+where no API key is available.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import string
+
+
+class ExactMatchScorer:
+    """Score answers by exact match after normalisation.
+
+    Normalisation:
+    - Strip leading / trailing whitespace.
+    - Lower-case.
+    - Remove punctuation (``string.punctuation``).
+    - Collapse internal whitespace to a single space.
+    """
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        text = text.strip().lower()
+        text = text.translate(str.maketrans("", "", string.punctuation))
+        text = re.sub(r"\s+", " ", text)
+        return text
+
+    def score(self, answer: str, reference: str) -> float:
+        """Return 1.0 if normalised *answer* matches normalised *reference*, else 0.0."""
+        return 1.0 if self._normalize(answer) == self._normalize(reference) else 0.0
+
+
+class GPT4oJudge:
+    """LLM-as-judge for borderline or free-form answers.
+
+    Reads ``OPENAI_API_KEY`` from the environment.  Raises ``RuntimeError`` at
+    construction time if the key is absent so that callers fail fast rather than
+    at the first actual judging call.
+
+    The model is controlled by the ``JUDGE_MODEL`` env var, defaulting to
+    ``gpt-4o``.
+    """
+
+    SYSTEM_PROMPT = (
+        "You are a precise evaluator for a graph-traversal QA benchmark. "
+        "The user will provide a ground-truth answer and a model answer. "
+        "Reply with only '1' if the model answer is correct, or '0' if incorrect."
+    )
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is not set. "
+                "Export it before using GPT4oJudge, or use MockJudge for dry runs."
+            )
+        self._api_key = api_key
+        self._model = os.environ.get("JUDGE_MODEL", "gpt-4o")
+
+    def score(self, answer: str, reference: str) -> float:
+        """Ask the judge model whether *answer* matches *reference*.
+
+        Returns 1.0 for correct, 0.0 for incorrect.
+        """
+        try:
+            import openai  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "openai package is required for GPT4oJudge. Install it with: "
+                "pip install openai"
+            ) from exc
+
+        client = openai.OpenAI(api_key=self._api_key)
+        user_content = (
+            f"Ground truth: {reference}\n"
+            f"Model answer: {answer}\n"
+            "Is the model answer correct? Reply with only '1' or '0'."
+        )
+        response = client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": self.SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            max_tokens=4,
+            temperature=0.0,
+        )
+        verdict = response.choices[0].message.content.strip()
+        return 1.0 if verdict.startswith("1") else 0.0
+
+
+class MockJudge:
+    """Deterministic judge for CPU dry-runs and CI (no API calls).
+
+    Returns 1.0 for any non-empty answer, 0.0 for empty.
+    """
+
+    def score(self, answer: str, reference: str) -> float:  # noqa: ARG002
+        return 1.0 if answer.strip() else 0.0

--- a/benchmark/graphwalks/judge.py
+++ b/benchmark/graphwalks/judge.py
@@ -1,97 +1,63 @@
-"""Scoring / judging for GraphWalks benchmark.
+"""GraphWalks scoring — purely programmatic set-overlap F1.
 
-GraphWalks has exact ground-truth answers (node names along a path), so
-``ExactMatchScorer`` is the primary judge.  ``GPT4oJudge`` is available for
-borderline or free-form cases.  ``MockJudge`` is used in dry-run / CI contexts
-where no API key is available.
+Verified against openai/graphwalks HF dataset card.
+
+GraphWalks is purely programmatic — no LLM judge required.  The official
+scoring method uses set-overlap F1 over node sets.  Models must end responses
+with ``Final Answer: [node1, node2, ...]``; responses not in this format
+score 0.
 """
 
 from __future__ import annotations
 
-import os
 import re
-import string
 
 
-class ExactMatchScorer:
-    """Score answers by exact match after normalisation.
+def parse_answer(response: str) -> list[str]:
+    """Extract node list from ``Final Answer: [node1, node2, ...]`` on the last line.
 
-    Normalisation:
-    - Strip leading / trailing whitespace.
-    - Lower-case.
-    - Remove punctuation (``string.punctuation``).
-    - Collapse internal whitespace to a single space.
+    Returns an empty list if the expected format is absent.
+    """
+    line = response.split("\n")[-1]
+    if "Final Answer:" not in line:
+        return []
+    match = re.search(r"Final Answer: ?\[.*\]", line)
+    if not match:
+        return []
+    inner = match.group(0).removeprefix("Final Answer:").strip()
+    inner = inner.strip("[]")
+    return [x.strip() for x in inner.split(",") if x.strip()]
+
+
+class SetF1Scorer:
+    """Set-overlap F1 scorer for GraphWalks.
+
+    Computes F1 between the predicted node set (parsed from the model's
+    ``Final Answer: [...]`` line) and the ground-truth node set.
+
+    Both task types (BFS, Parents) use this scorer.
     """
 
-    @staticmethod
-    def _normalize(text: str) -> str:
-        text = text.strip().lower()
-        text = text.translate(str.maketrans("", "", string.punctuation))
-        text = re.sub(r"\s+", " ", text)
-        return text
+    def score(self, prediction: str, reference: list[str]) -> float:
+        """Return set-overlap F1 in [0.0, 1.0].
 
-    def score(self, answer: str, reference: str) -> float:
-        """Return 1.0 if normalised *answer* matches normalised *reference*, else 0.0."""
-        return 1.0 if self._normalize(answer) == self._normalize(reference) else 0.0
-
-
-class GPT4oJudge:
-    """LLM-as-judge for borderline or free-form answers.
-
-    Reads ``OPENAI_API_KEY`` from the environment.  Raises ``RuntimeError`` at
-    construction time if the key is absent so that callers fail fast rather than
-    at the first actual judging call.
-
-    The model is controlled by the ``JUDGE_MODEL`` env var, defaulting to
-    ``gpt-4o``.
-    """
-
-    SYSTEM_PROMPT = (
-        "You are a precise evaluator for a graph-traversal QA benchmark. "
-        "The user will provide a ground-truth answer and a model answer. "
-        "Reply with only '1' if the model answer is correct, or '0' if incorrect."
-    )
-
-    def __init__(self) -> None:
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            raise RuntimeError(
-                "OPENAI_API_KEY is not set. "
-                "Export it before using GPT4oJudge, or use MockJudge for dry runs."
-            )
-        self._api_key = api_key
-        self._model = os.environ.get("JUDGE_MODEL", "gpt-4o")
-
-    def score(self, answer: str, reference: str) -> float:
-        """Ask the judge model whether *answer* matches *reference*.
-
-        Returns 1.0 for correct, 0.0 for incorrect.
+        Parameters
+        ----------
+        prediction:
+            Raw model response string.  Parsed via :func:`parse_answer`.
+        reference:
+            Ground-truth node list.
         """
-        try:
-            import openai  # noqa: PLC0415
-        except ImportError as exc:  # pragma: no cover
-            raise RuntimeError(
-                "openai package is required for GPT4oJudge. Install it with: "
-                "pip install openai"
-            ) from exc
-
-        client = openai.OpenAI(api_key=self._api_key)
-        user_content = (
-            f"Ground truth: {reference}\n"
-            f"Model answer: {answer}\n"
-            "Is the model answer correct? Reply with only '1' or '0'."
-        )
-        response = client.chat.completions.create(
-            model=self._model,
-            messages=[
-                {"role": "system", "content": self.SYSTEM_PROMPT},
-                {"role": "user", "content": user_content},
-            ],
-            max_tokens=4,
-            temperature=0.0,
-        )
-        verdict = response.choices[0].message.content.strip()
-        return 1.0 if verdict.startswith("1") else 0.0
+        sampled_set = set(parse_answer(prediction))
+        truth_set = set(reference)
+        n_sampled = len(sampled_set)
+        n_golden = len(truth_set)
+        n_overlap = len(sampled_set & truth_set)
+        recall = n_overlap / n_golden if n_golden > 0 else 0
+        precision = n_overlap / n_sampled if n_sampled > 0 else 0
+        if recall + precision == 0:
+            return 1.0 if n_golden == 0 else 0.0
+        return 2 * (recall * precision) / (recall + precision)
 
 
 class MockJudge:
@@ -100,5 +66,5 @@ class MockJudge:
     Returns 1.0 for any non-empty answer, 0.0 for empty.
     """
 
-    def score(self, answer: str, reference: str) -> float:  # noqa: ARG002
+    def score(self, answer: str, reference: list[str]) -> float:  # noqa: ARG002
         return 1.0 if answer.strip() else 0.0

--- a/benchmark/graphwalks/results.py
+++ b/benchmark/graphwalks/results.py
@@ -1,0 +1,246 @@
+"""Results schema for the GraphWalks benchmark.
+
+Every question result stores ``restore_mode`` as a Literal["warm", "cold"] so
+that warm/cold splits are always preserved in serialised output and are never
+inferred after the fact.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+
+@dataclass
+class QuestionResult:
+    """Per-question benchmark result."""
+
+    question_id: str
+    graph_size: int  # number of nodes
+    num_hops: int
+    restore_mode: Literal["warm", "cold"]
+
+    # Baseline (full context every turn, no snapshot)
+    baseline_ttft_s: float
+    baseline_input_tokens: int
+    baseline_output_tokens: int
+    baseline_answer: str
+    baseline_score: float
+
+    # Engram (snapshot-restored)
+    engram_ttft_s: float
+    engram_input_tokens: int
+    engram_output_tokens: int
+    engram_answer: str
+    engram_score: float
+
+    # ------------------------------------------------------------------
+    # Derived metrics (read-only properties)
+    # ------------------------------------------------------------------
+
+    @property
+    def token_reduction(self) -> float:
+        """Fraction of input tokens saved versus baseline.
+
+        token_reduction = 1 - engram_input_tokens / baseline_input_tokens
+
+        A value of 0.80 means Engram sent 80% fewer tokens.
+        Returns 0.0 when baseline_input_tokens is zero (degenerate case).
+        """
+        if self.baseline_input_tokens == 0:
+            return 0.0
+        return 1.0 - self.engram_input_tokens / self.baseline_input_tokens
+
+    @property
+    def ttft_speedup(self) -> float:
+        """Ratio of baseline TTFT to Engram TTFT (>1 means Engram is faster).
+
+        Returns 1.0 when engram_ttft_s is zero (degenerate case).
+        """
+        if self.engram_ttft_s == 0.0:
+            return 1.0
+        return self.baseline_ttft_s / self.engram_ttft_s
+
+    @property
+    def compute_amortization(self) -> float:
+        """Fraction of prefill compute amortised across warm restores.
+
+        Defined as token_reduction for warm results; 0.0 for cold (no
+        amortisation possible if the snapshot was not already available).
+        """
+        if self.restore_mode == "warm":
+            return self.token_reduction
+        return 0.0
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        # Append computed metrics so they appear in serialised output.
+        d["token_reduction"] = self.token_reduction
+        d["ttft_speedup"] = self.ttft_speedup
+        d["compute_amortization"] = self.compute_amortization
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "QuestionResult":
+        # Drop computed keys that may be present in stored JSON.
+        keep = {
+            k for k in d
+            if k not in ("token_reduction", "ttft_speedup", "compute_amortization")
+        }
+        return cls(**{k: d[k] for k in keep})
+
+
+def _safe_mean(values: List[float]) -> Optional[float]:
+    return sum(values) / len(values) if values else None
+
+
+@dataclass
+class RunSummary:
+    """Aggregated results for a single benchmark run."""
+
+    benchmark: str = "graphwalks"
+    model: str = ""
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    results: List[QuestionResult] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Warm / cold split helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def warm_results(self) -> List[QuestionResult]:
+        return [r for r in self.results if r.restore_mode == "warm"]
+
+    @property
+    def cold_results(self) -> List[QuestionResult]:
+        return [r for r in self.results if r.restore_mode == "cold"]
+
+    # ------------------------------------------------------------------
+    # Aggregate metrics (all results)
+    # ------------------------------------------------------------------
+
+    @property
+    def token_reduction(self) -> Optional[float]:
+        vals = [r.token_reduction for r in self.results]
+        return _safe_mean(vals)
+
+    @property
+    def ttft_speedup(self) -> Optional[float]:
+        vals = [r.ttft_speedup for r in self.results]
+        return _safe_mean(vals)
+
+    @property
+    def compute_amortization(self) -> Optional[float]:
+        vals = [r.compute_amortization for r in self.results]
+        return _safe_mean(vals)
+
+    # Warm-only aggregates
+    @property
+    def warm_token_reduction(self) -> Optional[float]:
+        vals = [r.token_reduction for r in self.warm_results]
+        return _safe_mean(vals)
+
+    @property
+    def warm_ttft_speedup(self) -> Optional[float]:
+        vals = [r.ttft_speedup for r in self.warm_results]
+        return _safe_mean(vals)
+
+    # Cold-only aggregates
+    @property
+    def cold_token_reduction(self) -> Optional[float]:
+        vals = [r.token_reduction for r in self.cold_results]
+        return _safe_mean(vals)
+
+    @property
+    def cold_ttft_speedup(self) -> Optional[float]:
+        vals = [r.ttft_speedup for r in self.cold_results]
+        return _safe_mean(vals)
+
+    # ------------------------------------------------------------------
+    # Per-hop breakdown
+    # ------------------------------------------------------------------
+
+    def by_hop_count(self) -> Dict[int, List[QuestionResult]]:
+        """Return results grouped by num_hops."""
+        groups: Dict[int, List[QuestionResult]] = {}
+        for r in self.results:
+            groups.setdefault(r.num_hops, []).append(r)
+        return groups
+
+    def metrics_by_hop(self) -> Dict[int, dict]:
+        """Aggregate metrics broken down by hop count."""
+        breakdown: Dict[int, dict] = {}
+        for hop, group in self.by_hop_count().items():
+            breakdown[hop] = {
+                "n": len(group),
+                "token_reduction": _safe_mean([r.token_reduction for r in group]),
+                "ttft_speedup": _safe_mean([r.ttft_speedup for r in group]),
+                "compute_amortization": _safe_mean(
+                    [r.compute_amortization for r in group]
+                ),
+                "baseline_score": _safe_mean([r.baseline_score for r in group]),
+                "engram_score": _safe_mean([r.engram_score for r in group]),
+            }
+        return breakdown
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "benchmark": self.benchmark,
+            "model": self.model,
+            "timestamp": self.timestamp,
+            "n_total": len(self.results),
+            "n_warm": len(self.warm_results),
+            "n_cold": len(self.cold_results),
+            "token_reduction": self.token_reduction,
+            "ttft_speedup": self.ttft_speedup,
+            "compute_amortization": self.compute_amortization,
+            "warm_token_reduction": self.warm_token_reduction,
+            "warm_ttft_speedup": self.warm_ttft_speedup,
+            "cold_token_reduction": self.cold_token_reduction,
+            "cold_ttft_speedup": self.cold_ttft_speedup,
+            "metrics_by_hop": self.metrics_by_hop(),
+            "results": [r.to_dict() for r in self.results],
+        }
+
+    def to_jsonl(self, path: "str | Path") -> None:
+        """Write results to a JSONL file (one JSON object per line).
+
+        The first line is the run-level summary header; subsequent lines are
+        per-question results.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            header = {k: v for k, v in self.to_dict().items() if k != "results"}
+            fh.write(json.dumps(header) + "\n")
+            for r in self.results:
+                fh.write(json.dumps(r.to_dict()) + "\n")
+
+    @classmethod
+    def from_jsonl(cls, path: "str | Path") -> "RunSummary":
+        """Load a RunSummary from a JSONL file written by ``to_jsonl``."""
+        path = Path(path)
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if not lines:
+            raise ValueError(f"Empty JSONL file: {path}")
+        header = json.loads(lines[0])
+        results = [QuestionResult.from_dict(json.loads(ln)) for ln in lines[1:]]
+        return cls(
+            benchmark=header.get("benchmark", "graphwalks"),
+            model=header.get("model", ""),
+            timestamp=header.get("timestamp", ""),
+            results=results,
+        )

--- a/benchmark/graphwalks/runner.py
+++ b/benchmark/graphwalks/runner.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from .judge import ExactMatchScorer, MockJudge
+from .judge import MockJudge, SetF1Scorer
 from .results import QuestionResult, RunSummary
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ class Question:
     question_id: str
     graph_text: str  # Textual description of the graph
     question: str    # Natural-language question to answer
-    answer: str      # Ground-truth answer
+    answer: list     # Ground-truth answer node list
     num_hops: int
     num_nodes: int
 
@@ -140,7 +140,7 @@ class GraphWalksRunner:
         self.model_url = model_url
         self.snapshot_dir = Path(snapshot_dir)
         self.model = model
-        self.scorer = scorer if scorer is not None else ExactMatchScorer()
+        self.scorer = scorer if scorer is not None else SetF1Scorer()
         self.http_client = http_client
 
     # ------------------------------------------------------------------
@@ -151,7 +151,10 @@ class GraphWalksRunner:
         """Run full-context baseline for every question."""
         results: List[QuestionResult] = []
         for q in questions:
-            prompt = f"{q.graph_text}\n\n{q.question}"
+            prompt = (
+                f"{q.graph_text}\n\n{q.question}\n\n"
+                "End your response with exactly: Final Answer: [node1, node2, ...]"
+            )
             input_tokens = _count_tokens(prompt)
 
             answer, ttft = _post_completion(
@@ -228,12 +231,15 @@ class GraphWalksRunner:
             is_warm = self._snapshot_exists(q.question_id)
             restore_mode: Literal["warm", "cold"] = "warm" if is_warm else "cold"
 
+            answer_instruction = (
+                "\n\nEnd your response with exactly: Final Answer: [node1, node2, ...]"
+            )
             if is_warm:
                 # Warm: only send the question — graph context is in the snapshot.
-                prompt = q.question
+                prompt = q.question + answer_instruction
             else:
                 # Cold: send full context, then persist a stub snapshot.
-                prompt = f"{q.graph_text}\n\n{q.question}"
+                prompt = f"{q.graph_text}\n\n{q.question}" + answer_instruction
                 self._save_stub_snapshot(q.question_id, q.graph_text)
 
             input_tokens = _count_tokens(prompt)
@@ -417,7 +423,7 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    scorer = MockJudge() if args.dry_run else ExactMatchScorer()
+    scorer = MockJudge() if args.dry_run else SetF1Scorer()
 
     if args.dry_run:
         from .download import generate_synthetic_question  # noqa: PLC0415

--- a/benchmark/graphwalks/runner.py
+++ b/benchmark/graphwalks/runner.py
@@ -1,0 +1,484 @@
+"""GraphWalks benchmark runner.
+
+Two-phase execution:
+1. ``run_baseline`` — sends full graph context + question to the model every
+   time (simulating a stateless deployment).
+2. ``run_engram`` — checks for a pre-saved snapshot; if present (warm), sends
+   only the question; if absent (cold), sends full context, then saves a stub
+   snapshot.
+
+Usage
+-----
+python -m benchmark.graphwalks.runner \\
+    --model-url http://localhost:30000/v1 \\
+    --snapshot-dir /tmp/snapshots \\
+    --output results/graphwalks.jsonl \\
+    --num-questions 100 \\
+    --mode both
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Optional
+
+from .judge import ExactMatchScorer, MockJudge
+from .results import QuestionResult, RunSummary
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Question:
+    """A single GraphWalks question."""
+
+    question_id: str
+    graph_text: str  # Textual description of the graph
+    question: str    # Natural-language question to answer
+    answer: str      # Ground-truth answer
+    num_hops: int
+    num_nodes: int
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _post_completion(
+    model_url: str,
+    prompt: str,
+    model: str,
+    timeout: float = 120.0,
+    http_client=None,
+) -> tuple[str, float]:
+    """Send a chat completion request; return (answer_text, ttft_seconds).
+
+    If *http_client* is provided (for testing), calls
+    ``http_client.post(url, json=payload)`` and expects a dict response.
+    Otherwise uses the ``requests`` library.
+    """
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 256,
+        "temperature": 0.0,
+    }
+    url = model_url.rstrip("/") + "/chat/completions"
+
+    t0 = time.perf_counter()
+
+    if http_client is not None:
+        response_data = http_client.post(url, json=payload)
+    else:
+        import requests  # noqa: PLC0415
+
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        response_data = resp.json()
+
+    ttft = time.perf_counter() - t0
+
+    try:
+        text = response_data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        logger.warning("Unexpected response shape: %s — %s", response_data, exc)
+        text = ""
+
+    return text, ttft
+
+
+def _count_tokens(text: str) -> int:
+    """Token count proxy: split on whitespace."""
+    return len(text.split())
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+class GraphWalksRunner:
+    """Orchestrates baseline and Engram runs for a list of questions.
+
+    Parameters
+    ----------
+    model_url:
+        Base URL of the OpenAI-compatible inference server
+        (e.g. ``http://localhost:30000/v1``).
+    snapshot_dir:
+        Directory where Engram snapshots are stored.  Each snapshot lives at
+        ``<snapshot_dir>/<question_id>/snapshot.json``.
+    model:
+        Model name to pass in the ``"model"`` field of each request.
+    scorer:
+        Scoring object with a ``.score(answer, reference) -> float`` method.
+        Defaults to ``ExactMatchScorer``.
+    http_client:
+        Optional test double for the HTTP layer.  Must expose a
+        ``.post(url, json=...) -> dict`` interface.
+    """
+
+    def __init__(
+        self,
+        model_url: str = "http://localhost:30000/v1",
+        snapshot_dir: "str | Path" = "/tmp/engram_snapshots",
+        model: str = "default",
+        scorer=None,
+        http_client=None,
+    ) -> None:
+        self.model_url = model_url
+        self.snapshot_dir = Path(snapshot_dir)
+        self.model = model
+        self.scorer = scorer if scorer is not None else ExactMatchScorer()
+        self.http_client = http_client
+
+    # ------------------------------------------------------------------
+    # Baseline
+    # ------------------------------------------------------------------
+
+    def run_baseline(self, questions: List[Question]) -> List[QuestionResult]:
+        """Run full-context baseline for every question."""
+        results: List[QuestionResult] = []
+        for q in questions:
+            prompt = f"{q.graph_text}\n\n{q.question}"
+            input_tokens = _count_tokens(prompt)
+
+            answer, ttft = _post_completion(
+                self.model_url,
+                prompt,
+                self.model,
+                http_client=self.http_client,
+            )
+
+            output_tokens = _count_tokens(answer)
+            score = self.scorer.score(answer, q.answer)
+
+            # Baseline always runs the full context; it has no warm/cold
+            # distinction.  We label it "cold" to reflect that no state was
+            # reused.
+            results.append(
+                QuestionResult(
+                    question_id=q.question_id,
+                    graph_size=q.num_nodes,
+                    num_hops=q.num_hops,
+                    restore_mode="cold",
+                    baseline_ttft_s=ttft,
+                    baseline_input_tokens=input_tokens,
+                    baseline_output_tokens=output_tokens,
+                    baseline_answer=answer,
+                    baseline_score=score,
+                    # Engram fields are placeholders until run_engram fills them.
+                    engram_ttft_s=0.0,
+                    engram_input_tokens=0,
+                    engram_output_tokens=0,
+                    engram_answer="",
+                    engram_score=0.0,
+                )
+            )
+            logger.debug(
+                "Baseline %s: ttft=%.3fs tokens=%d score=%.1f",
+                q.question_id,
+                ttft,
+                input_tokens,
+                score,
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Engram (snapshot-aware)
+    # ------------------------------------------------------------------
+
+    def _snapshot_path(self, question_id: str) -> Path:
+        return self.snapshot_dir / question_id / "snapshot.json"
+
+    def _snapshot_exists(self, question_id: str) -> bool:
+        return self._snapshot_path(question_id).exists()
+
+    def _save_stub_snapshot(self, question_id: str, graph_text: str) -> None:
+        """Write a minimal stub snapshot so subsequent runs are warm."""
+        snap_path = self._snapshot_path(question_id)
+        snap_path.parent.mkdir(parents=True, exist_ok=True)
+        stub = {
+            "question_id": question_id,
+            "graph_text_hash": hash(graph_text),
+            "snapshot_version": 1,
+        }
+        snap_path.write_text(json.dumps(stub), encoding="utf-8")
+
+    def run_engram(self, questions: List[Question]) -> List[QuestionResult]:
+        """Run Engram (snapshot-restored) inference for every question.
+
+        Warm questions send only the question prompt (graph state already in
+        snapshot).  Cold questions send the full context and then save a stub
+        snapshot for future warm runs.
+        """
+        results: List[QuestionResult] = []
+        for q in questions:
+            is_warm = self._snapshot_exists(q.question_id)
+            restore_mode: Literal["warm", "cold"] = "warm" if is_warm else "cold"
+
+            if is_warm:
+                # Warm: only send the question — graph context is in the snapshot.
+                prompt = q.question
+            else:
+                # Cold: send full context, then persist a stub snapshot.
+                prompt = f"{q.graph_text}\n\n{q.question}"
+                self._save_stub_snapshot(q.question_id, q.graph_text)
+
+            input_tokens = _count_tokens(prompt)
+
+            answer, ttft = _post_completion(
+                self.model_url,
+                prompt,
+                self.model,
+                http_client=self.http_client,
+            )
+
+            output_tokens = _count_tokens(answer)
+            score = self.scorer.score(answer, q.answer)
+
+            results.append(
+                QuestionResult(
+                    question_id=q.question_id,
+                    graph_size=q.num_nodes,
+                    num_hops=q.num_hops,
+                    restore_mode=restore_mode,
+                    # Baseline fields are placeholders; run_baseline fills them.
+                    baseline_ttft_s=0.0,
+                    baseline_input_tokens=0,
+                    baseline_output_tokens=0,
+                    baseline_answer="",
+                    baseline_score=0.0,
+                    engram_ttft_s=ttft,
+                    engram_input_tokens=input_tokens,
+                    engram_output_tokens=output_tokens,
+                    engram_answer=answer,
+                    engram_score=score,
+                )
+            )
+            logger.debug(
+                "Engram %s (%s): ttft=%.3fs tokens=%d score=%.1f",
+                q.question_id,
+                restore_mode,
+                ttft,
+                input_tokens,
+                score,
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Combined run helpers
+    # ------------------------------------------------------------------
+
+    def merge_results(
+        self,
+        baseline: List[QuestionResult],
+        engram: List[QuestionResult],
+    ) -> List[QuestionResult]:
+        """Merge baseline and Engram results into a unified list.
+
+        The Engram ``restore_mode`` label is authoritative (warm/cold).
+        Baseline measurements are copied into the combined record.
+        """
+        baseline_by_id = {r.question_id: r for r in baseline}
+        merged: List[QuestionResult] = []
+        for er in engram:
+            br = baseline_by_id.get(er.question_id)
+            if br is None:
+                logger.warning("No baseline result for %s", er.question_id)
+                merged.append(er)
+                continue
+            merged.append(
+                QuestionResult(
+                    question_id=er.question_id,
+                    graph_size=er.graph_size,
+                    num_hops=er.num_hops,
+                    restore_mode=er.restore_mode,
+                    baseline_ttft_s=br.baseline_ttft_s,
+                    baseline_input_tokens=br.baseline_input_tokens,
+                    baseline_output_tokens=br.baseline_output_tokens,
+                    baseline_answer=br.baseline_answer,
+                    baseline_score=br.baseline_score,
+                    engram_ttft_s=er.engram_ttft_s,
+                    engram_input_tokens=er.engram_input_tokens,
+                    engram_output_tokens=er.engram_output_tokens,
+                    engram_answer=er.engram_answer,
+                    engram_score=er.engram_score,
+                )
+            )
+        return merged
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="GraphWalks benchmark runner for Engram.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--model-url",
+        default="http://localhost:30000/v1",
+        help="Base URL of the OpenAI-compatible inference server.",
+    )
+    p.add_argument(
+        "--model",
+        default="default",
+        help='Model name to pass in the "model" field.',
+    )
+    p.add_argument(
+        "--snapshot-dir",
+        default="/tmp/engram_snapshots",
+        help="Directory for Engram snapshot files.",
+    )
+    p.add_argument(
+        "--output",
+        default="results/graphwalks.jsonl",
+        help="Output JSONL path.",
+    )
+    p.add_argument(
+        "--num-questions",
+        type=int,
+        default=100,
+        help="Number of questions to run (0 = all).",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["baseline", "engram", "both"],
+        default="both",
+        help="Which phases to run.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Use synthetic questions and MockJudge; no live server required.",
+    )
+    p.add_argument(
+        "--data-path",
+        default=None,
+        help="Path to a JSONL file of questions. Defaults to the downloaded dataset.",
+    )
+    return p
+
+
+def _load_questions(data_path: Optional[str], num_questions: int) -> List[Question]:
+    """Load questions from a JSONL file."""
+    if data_path is None:
+        default = (
+            Path(__file__).parent / "data" / "graphwalks" / "test_dry_run.jsonl"
+        )
+        data_path = str(default)
+
+    path = Path(data_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Dataset not found at {path}. "
+            "Run: python -m benchmark.graphwalks.download"
+        )
+
+    questions: List[Question] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            questions.append(
+                Question(
+                    question_id=d["question_id"],
+                    graph_text=d["graph_text"],
+                    question=d["question"],
+                    answer=d["answer"],
+                    num_hops=d["num_hops"],
+                    num_nodes=d["num_nodes"],
+                )
+            )
+            if num_questions and len(questions) >= num_questions:
+                break
+    return questions
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    scorer = MockJudge() if args.dry_run else ExactMatchScorer()
+
+    if args.dry_run:
+        from .download import generate_synthetic_question  # noqa: PLC0415
+
+        raw = [generate_synthetic_question(num_nodes=5, num_hops=3, seed=i) for i in range(5)]
+        questions = [
+            Question(
+                question_id=d["question_id"],
+                graph_text=d["graph_text"],
+                question=d["question"],
+                answer=d["answer"],
+                num_hops=d["num_hops"],
+                num_nodes=d["num_nodes"],
+            )
+            for d in raw
+        ]
+    else:
+        questions = _load_questions(args.data_path, args.num_questions)
+
+    runner = GraphWalksRunner(
+        model_url=args.model_url,
+        snapshot_dir=args.snapshot_dir,
+        model=args.model,
+        scorer=scorer,
+    )
+
+    baseline_results: List[QuestionResult] = []
+    engram_results: List[QuestionResult] = []
+
+    if args.mode in ("baseline", "both"):
+        logger.info("Running baseline phase (%d questions)…", len(questions))
+        baseline_results = runner.run_baseline(questions)
+
+    if args.mode in ("engram", "both"):
+        logger.info("Running Engram phase (%d questions)…", len(questions))
+        engram_results = runner.run_engram(questions)
+
+    if args.mode == "both":
+        merged = runner.merge_results(baseline_results, engram_results)
+    elif args.mode == "baseline":
+        merged = baseline_results
+    else:
+        merged = engram_results
+
+    summary = RunSummary(model=args.model, results=merged)
+    summary.to_jsonl(args.output)
+    logger.info("Results written to %s", args.output)
+
+    # Print a brief summary to stdout.
+    print("\n=== GraphWalks Run Summary ===")
+    print(f"  Model        : {summary.model}")
+    print(f"  Questions    : {len(merged)}")
+    print(f"  Warm         : {len(summary.warm_results)}")
+    print(f"  Cold         : {len(summary.cold_results)}")
+    if summary.token_reduction is not None:
+        print(f"  Token Reduction (all)  : {summary.token_reduction:.1%}")
+    if summary.warm_token_reduction is not None:
+        print(f"  Token Reduction (warm) : {summary.warm_token_reduction:.1%}")
+    if summary.ttft_speedup is not None:
+        print(f"  TTFT Speedup           : {summary.ttft_speedup:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/graphwalks/test_dry_run.py
+++ b/benchmark/graphwalks/test_dry_run.py
@@ -1,0 +1,434 @@
+"""GraphWalks benchmark dry-run tests.
+
+Verifies all pipeline stages (schema, scoring, runner warm/cold logic,
+serialisation) on CPU with no GPU and no live inference server.
+
+Run with:
+    pytest benchmark/graphwalks/test_dry_run.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchmark.graphwalks.download import generate_synthetic_question
+from benchmark.graphwalks.judge import ExactMatchScorer, MockJudge
+from benchmark.graphwalks.results import QuestionResult, RunSummary
+from benchmark.graphwalks.runner import GraphWalksRunner, Question
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+# 5 synthetic graph questions covering different hop counts.
+SYNTHETIC_QUESTIONS = [
+    generate_synthetic_question(num_nodes=6, num_hops=h, seed=i)
+    for i, h in enumerate([1, 2, 3, 2, 1])
+]
+
+
+def _make_question(d: Dict[str, Any]) -> Question:
+    return Question(
+        question_id=d["question_id"],
+        graph_text=d["graph_text"],
+        question=d["question"],
+        answer=d["answer"],
+        num_hops=d["num_hops"],
+        num_nodes=d["num_nodes"],
+    )
+
+
+QUESTIONS = [_make_question(d) for d in SYNTHETIC_QUESTIONS]
+
+
+def _mock_response(content: str = "node B") -> Dict:
+    """Build a minimal OpenAI-compatible chat completion response dict."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def mock_http_client():
+    """An HTTP client stub that returns a canned completion response."""
+    client = MagicMock()
+    client.post.return_value = _mock_response("node B")
+    return client
+
+
+@pytest.fixture
+def tmp_snapshot_dir(tmp_path: Path) -> Path:
+    return tmp_path / "snapshots"
+
+
+# ---------------------------------------------------------------------------
+# TestResultsSchema
+# ---------------------------------------------------------------------------
+
+
+class TestResultsSchema:
+    def _make_result(
+        self,
+        restore_mode: str = "cold",
+        baseline_input: int = 200,
+        engram_input: int = 40,
+        baseline_ttft: float = 1.0,
+        engram_ttft: float = 0.2,
+        num_hops: int = 2,
+    ) -> QuestionResult:
+        return QuestionResult(
+            question_id="q1",
+            graph_size=5,
+            num_hops=num_hops,
+            restore_mode=restore_mode,  # type: ignore[arg-type]
+            baseline_ttft_s=baseline_ttft,
+            baseline_input_tokens=baseline_input,
+            baseline_output_tokens=10,
+            baseline_answer="B",
+            baseline_score=1.0,
+            engram_ttft_s=engram_ttft,
+            engram_input_tokens=engram_input,
+            engram_output_tokens=10,
+            engram_answer="B",
+            engram_score=1.0,
+        )
+
+    def test_question_result_warm_cold_label(self):
+        """restore_mode must be preserved exactly as set."""
+        warm = self._make_result(restore_mode="warm")
+        cold = self._make_result(restore_mode="cold")
+        assert warm.restore_mode == "warm"
+        assert cold.restore_mode == "cold"
+
+    def test_token_reduction_metric(self):
+        r = self._make_result(baseline_input=200, engram_input=40)
+        assert abs(r.token_reduction - 0.80) < 1e-9
+
+    def test_ttft_speedup_metric(self):
+        r = self._make_result(baseline_ttft=1.0, engram_ttft=0.25)
+        assert abs(r.ttft_speedup - 4.0) < 1e-9
+
+    def test_compute_amortization_warm(self):
+        r = self._make_result(restore_mode="warm", baseline_input=200, engram_input=40)
+        # Warm: amortization == token_reduction
+        assert abs(r.compute_amortization - r.token_reduction) < 1e-9
+
+    def test_compute_amortization_cold(self):
+        r = self._make_result(restore_mode="cold")
+        # Cold: no amortization
+        assert r.compute_amortization == 0.0
+
+    def test_token_reduction_zero_baseline(self):
+        r = self._make_result(baseline_input=0, engram_input=0)
+        assert r.token_reduction == 0.0
+
+    def test_ttft_speedup_zero_engram(self):
+        r = self._make_result(baseline_ttft=1.0, engram_ttft=0.0)
+        assert r.ttft_speedup == 1.0
+
+    def test_run_summary_aggregates_by_hops(self):
+        results = [
+            self._make_result(restore_mode="warm", num_hops=1),
+            self._make_result(restore_mode="warm", num_hops=2),
+            self._make_result(restore_mode="cold", num_hops=2),
+        ]
+        # Give distinct question IDs so we can have multiple in one summary.
+        for i, r in enumerate(results):
+            r.question_id = f"q{i}"
+
+        summary = RunSummary(model="test-model", results=results)
+        by_hop = summary.metrics_by_hop()
+        assert 1 in by_hop
+        assert 2 in by_hop
+        assert by_hop[1]["n"] == 1
+        assert by_hop[2]["n"] == 2
+
+    def test_warm_cold_split_on_summary(self):
+        warm_r = self._make_result(restore_mode="warm")
+        warm_r.question_id = "qw"
+        cold_r = self._make_result(restore_mode="cold")
+        cold_r.question_id = "qc"
+        summary = RunSummary(results=[warm_r, cold_r])
+        assert len(summary.warm_results) == 1
+        assert len(summary.cold_results) == 1
+
+    def test_metrics(self):
+        r1 = self._make_result(
+            restore_mode="warm",
+            baseline_input=200,
+            engram_input=40,
+            baseline_ttft=1.0,
+            engram_ttft=0.25,
+        )
+        r1.question_id = "q1"
+        r2 = self._make_result(
+            restore_mode="cold",
+            baseline_input=200,
+            engram_input=200,
+            baseline_ttft=1.0,
+            engram_ttft=1.0,
+        )
+        r2.question_id = "q2"
+        summary = RunSummary(results=[r1, r2])
+        # Average token reduction: (0.8 + 0.0) / 2 = 0.4
+        assert abs(summary.token_reduction - 0.4) < 1e-9  # type: ignore[operator]
+        # Warm-only
+        assert abs(summary.warm_token_reduction - 0.80) < 1e-9  # type: ignore[operator]
+
+    def test_jsonl_roundtrip(self):
+        results = []
+        for i, q in enumerate(SYNTHETIC_QUESTIONS):
+            mode = "warm" if i % 2 == 0 else "cold"
+            results.append(
+                QuestionResult(
+                    question_id=q["question_id"],
+                    graph_size=q["num_nodes"],
+                    num_hops=q["num_hops"],
+                    restore_mode=mode,  # type: ignore[arg-type]
+                    baseline_ttft_s=0.5,
+                    baseline_input_tokens=100,
+                    baseline_output_tokens=10,
+                    baseline_answer="B",
+                    baseline_score=1.0,
+                    engram_ttft_s=0.1,
+                    engram_input_tokens=20,
+                    engram_output_tokens=10,
+                    engram_answer="B",
+                    engram_score=1.0,
+                )
+            )
+
+        summary = RunSummary(model="dry-run-model", results=results)
+
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "run.jsonl"
+            summary.to_jsonl(path)
+
+            loaded = RunSummary.from_jsonl(path)
+
+        assert loaded.model == summary.model
+        assert len(loaded.results) == len(summary.results)
+        for orig, loaded_r in zip(summary.results, loaded.results):
+            assert loaded_r.question_id == orig.question_id
+            assert loaded_r.restore_mode == orig.restore_mode
+            assert loaded_r.num_hops == orig.num_hops
+
+
+# ---------------------------------------------------------------------------
+# TestSyntheticGeneration
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticGeneration:
+    def test_generate_synthetic_question_keys(self):
+        q = generate_synthetic_question(num_nodes=5, num_hops=3, seed=0)
+        required_keys = {
+            "question_id", "graph_text", "question", "answer",
+            "num_hops", "num_nodes",
+        }
+        assert required_keys.issubset(q.keys())
+
+    def test_generate_synthetic_question_answer_correctness(self):
+        """The generated answer must be reachable in num_hops steps."""
+        import string  # noqa: PLC0415
+
+        for seed in range(5):
+            q = generate_synthetic_question(num_nodes=6, num_hops=2, seed=seed)
+            graph_text = q["graph_text"]
+            answer = q["answer"]
+            # The answer should appear in the graph description
+            assert answer in graph_text, f"Answer '{answer}' not in graph: {graph_text}"
+            # The answer must be a valid uppercase letter
+            assert answer in string.ascii_uppercase
+
+    def test_generate_synthetic_question_reproducible(self):
+        q1 = generate_synthetic_question(num_nodes=5, num_hops=2, seed=42)
+        q2 = generate_synthetic_question(num_nodes=5, num_hops=2, seed=42)
+        assert q1 == q2
+
+    def test_generate_synthetic_question_different_seeds(self):
+        q0 = generate_synthetic_question(num_nodes=6, num_hops=2, seed=0)
+        q1 = generate_synthetic_question(num_nodes=6, num_hops=2, seed=1)
+        # Different seeds should (generally) produce different question IDs.
+        assert q0["question_id"] != q1["question_id"]
+
+    def test_exact_match_scorer_match(self):
+        scorer = ExactMatchScorer()
+        assert scorer.score("Node B", "node b") == 1.0
+
+    def test_exact_match_scorer_no_match(self):
+        scorer = ExactMatchScorer()
+        assert scorer.score("Node C", "Node B") == 0.0
+
+    def test_exact_match_scorer_normalized(self):
+        scorer = ExactMatchScorer()
+        # Punctuation and case should not matter.
+        assert scorer.score("B!", "B") == 1.0
+        assert scorer.score("  b  ", "B") == 1.0
+
+    def test_mock_judge_non_empty(self):
+        judge = MockJudge()
+        assert judge.score("some answer", "reference") == 1.0
+
+    def test_mock_judge_empty(self):
+        judge = MockJudge()
+        assert judge.score("", "reference") == 0.0
+        assert judge.score("   ", "reference") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestRunnerDryRun
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerDryRun:
+    """All tests mock the HTTP layer; no GPU or live server required."""
+
+    def _make_runner(
+        self,
+        tmp_snapshot_dir: Path,
+        answer: str = "node B",
+        scorer=None,
+    ) -> GraphWalksRunner:
+        client = MagicMock()
+        client.post.return_value = _mock_response(answer)
+        return GraphWalksRunner(
+            model_url="http://mock-server/v1",
+            snapshot_dir=tmp_snapshot_dir,
+            model="mock-model",
+            scorer=scorer or MockJudge(),
+            http_client=client,
+        )
+
+    def test_baseline_run(self, tmp_snapshot_dir: Path):
+        runner = self._make_runner(tmp_snapshot_dir)
+        results = runner.run_baseline(QUESTIONS)
+
+        assert len(results) == len(QUESTIONS)
+        for r in results:
+            assert r.restore_mode == "cold"
+            assert r.baseline_ttft_s >= 0.0
+            assert r.baseline_input_tokens > 0
+            assert r.engram_input_tokens == 0  # Not set in baseline-only run
+
+    def test_engram_cold_run(self, tmp_snapshot_dir: Path):
+        """First run with no pre-existing snapshots → all cold."""
+        runner = self._make_runner(tmp_snapshot_dir)
+        results = runner.run_engram(QUESTIONS)
+
+        assert len(results) == len(QUESTIONS)
+        for r in results:
+            assert r.restore_mode == "cold", f"{r.question_id} should be cold"
+            assert r.engram_ttft_s >= 0.0
+            assert r.engram_input_tokens > 0
+
+    def test_engram_warm_run(self, tmp_snapshot_dir: Path):
+        """Pre-create snapshots → all warm."""
+        runner = self._make_runner(tmp_snapshot_dir)
+
+        # Pre-seed snapshots for every question.
+        for q in QUESTIONS:
+            snap = tmp_snapshot_dir / q.question_id / "snapshot.json"
+            snap.parent.mkdir(parents=True, exist_ok=True)
+            snap.write_text(json.dumps({"question_id": q.question_id}))
+
+        results = runner.run_engram(QUESTIONS)
+
+        assert len(results) == len(QUESTIONS)
+        for r in results:
+            assert r.restore_mode == "warm", f"{r.question_id} should be warm"
+
+    def test_warm_cold_labeling(self, tmp_snapshot_dir: Path):
+        """Mixed pre-existing snapshots produce correct warm/cold labels."""
+        runner = self._make_runner(tmp_snapshot_dir)
+
+        # Pre-seed only the first question.
+        first_q = QUESTIONS[0]
+        snap = tmp_snapshot_dir / first_q.question_id / "snapshot.json"
+        snap.parent.mkdir(parents=True, exist_ok=True)
+        snap.write_text(json.dumps({"question_id": first_q.question_id}))
+
+        results = runner.run_engram(QUESTIONS)
+
+        result_by_id = {r.question_id: r for r in results}
+        assert result_by_id[first_q.question_id].restore_mode == "warm"
+        for q in QUESTIONS[1:]:
+            assert result_by_id[q.question_id].restore_mode == "cold"
+
+    def test_cold_run_creates_snapshot(self, tmp_snapshot_dir: Path):
+        """Cold Engram run must create a stub snapshot file."""
+        runner = self._make_runner(tmp_snapshot_dir)
+        runner.run_engram(QUESTIONS[:1])
+
+        snap = tmp_snapshot_dir / QUESTIONS[0].question_id / "snapshot.json"
+        assert snap.exists(), "Stub snapshot should have been written after cold run"
+        data = json.loads(snap.read_text())
+        assert "question_id" in data
+
+    def test_warm_run_sends_shorter_prompt(self, tmp_snapshot_dir: Path):
+        """Warm Engram run should use fewer input tokens than cold."""
+        runner = self._make_runner(tmp_snapshot_dir)
+
+        q = QUESTIONS[0]
+
+        # Cold run first
+        cold_results = runner.run_engram([q])
+        cold_tokens = cold_results[0].engram_input_tokens
+
+        # The snapshot now exists → warm on second run
+        warm_results = runner.run_engram([q])
+        warm_tokens = warm_results[0].engram_input_tokens
+
+        assert warm_tokens < cold_tokens, (
+            f"Warm run ({warm_tokens} tokens) should use fewer tokens "
+            f"than cold run ({cold_tokens} tokens)"
+        )
+
+    def test_result_serialization(self, tmp_snapshot_dir: Path):
+        """Full pipeline → JSONL serialisation → reload round-trip."""
+        runner = self._make_runner(tmp_snapshot_dir)
+
+        baseline = runner.run_baseline(QUESTIONS)
+        engram = runner.run_engram(QUESTIONS)
+        merged = runner.merge_results(baseline, engram)
+
+        summary = RunSummary(model="mock-model", results=merged)
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "results.jsonl"
+            summary.to_jsonl(out)
+
+            loaded = RunSummary.from_jsonl(out)
+
+        assert len(loaded.results) == len(merged)
+        for orig, reloaded in zip(merged, loaded.results):
+            assert reloaded.question_id == orig.question_id
+            assert reloaded.restore_mode == orig.restore_mode
+
+    def test_merge_results_copies_baseline_fields(self, tmp_snapshot_dir: Path):
+        """merge_results must populate baseline_* from the baseline run."""
+        runner = self._make_runner(tmp_snapshot_dir)
+        baseline = runner.run_baseline(QUESTIONS[:1])
+        engram = runner.run_engram(QUESTIONS[:1])
+        merged = runner.merge_results(baseline, engram)
+
+        assert len(merged) == 1
+        r = merged[0]
+        # Baseline fields should come from the baseline run.
+        assert r.baseline_input_tokens == baseline[0].baseline_input_tokens
+        assert r.baseline_ttft_s == baseline[0].baseline_ttft_s
+        # Engram fields should come from the engram run.
+        assert r.engram_input_tokens == engram[0].engram_input_tokens

--- a/benchmark/graphwalks/test_dry_run.py
+++ b/benchmark/graphwalks/test_dry_run.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from benchmark.graphwalks.download import generate_synthetic_question
-from benchmark.graphwalks.judge import ExactMatchScorer, MockJudge
+from benchmark.graphwalks.judge import MockJudge, SetF1Scorer, parse_answer
 from benchmark.graphwalks.results import QuestionResult, RunSummary
 from benchmark.graphwalks.runner import GraphWalksRunner, Question
 
@@ -47,7 +47,7 @@ def _make_question(d: Dict[str, Any]) -> Question:
 QUESTIONS = [_make_question(d) for d in SYNTHETIC_QUESTIONS]
 
 
-def _mock_response(content: str = "node B") -> Dict:
+def _mock_response(content: str = "Final Answer: [B]") -> Dict:
     """Build a minimal OpenAI-compatible chat completion response dict."""
     return {
         "choices": [
@@ -65,7 +65,7 @@ def _mock_response(content: str = "node B") -> Dict:
 def mock_http_client():
     """An HTTP client stub that returns a canned completion response."""
     client = MagicMock()
-    client.post.return_value = _mock_response("node B")
+    client.post.return_value = _mock_response("Final Answer: [B]")
     return client
 
 
@@ -249,10 +249,13 @@ class TestSyntheticGeneration:
             q = generate_synthetic_question(num_nodes=6, num_hops=2, seed=seed)
             graph_text = q["graph_text"]
             answer = q["answer"]
+            # answer is now a list; check the single node
+            assert isinstance(answer, list) and len(answer) == 1
+            node = answer[0]
             # The answer should appear in the graph description
-            assert answer in graph_text, f"Answer '{answer}' not in graph: {graph_text}"
+            assert node in graph_text, f"Answer '{node}' not in graph: {graph_text}"
             # The answer must be a valid uppercase letter
-            assert answer in string.ascii_uppercase
+            assert node in string.ascii_uppercase
 
     def test_generate_synthetic_question_reproducible(self):
         q1 = generate_synthetic_question(num_nodes=5, num_hops=2, seed=42)
@@ -265,28 +268,102 @@ class TestSyntheticGeneration:
         # Different seeds should (generally) produce different question IDs.
         assert q0["question_id"] != q1["question_id"]
 
-    def test_exact_match_scorer_match(self):
-        scorer = ExactMatchScorer()
-        assert scorer.score("Node B", "node b") == 1.0
+    # ------------------------------------------------------------------
+    # parse_answer tests
+    # ------------------------------------------------------------------
 
-    def test_exact_match_scorer_no_match(self):
-        scorer = ExactMatchScorer()
-        assert scorer.score("Node C", "Node B") == 0.0
+    def test_parse_answer_correct_format(self):
+        assert parse_answer("some text\nFinal Answer: [A, B, C]") == ["A", "B", "C"]
 
-    def test_exact_match_scorer_normalized(self):
-        scorer = ExactMatchScorer()
-        # Punctuation and case should not matter.
-        assert scorer.score("B!", "B") == 1.0
-        assert scorer.score("  b  ", "B") == 1.0
+    def test_parse_answer_single_node(self):
+        assert parse_answer("Final Answer: [X]") == ["X"]
+
+    def test_parse_answer_missing_format(self):
+        assert parse_answer("The answer is B") == []
+
+    def test_parse_answer_partial_format_no_brackets(self):
+        assert parse_answer("Final Answer: B") == []
+
+    def test_parse_answer_empty_list(self):
+        assert parse_answer("Final Answer: []") == []
+
+    def test_parse_answer_whitespace_in_nodes(self):
+        assert parse_answer("Final Answer: [ A , B ]") == ["A", "B"]
+
+    def test_parse_answer_uses_last_line(self):
+        # Only the last line matters; a Final Answer on an earlier line is ignored
+        result = parse_answer("Final Answer: [X]\nSome other line\nFinal Answer: [Y]")
+        assert result == ["Y"]
+
+    def test_parse_answer_no_final_answer_keyword(self):
+        assert parse_answer("") == []
+
+    # ------------------------------------------------------------------
+    # SetF1Scorer tests
+    # ------------------------------------------------------------------
+
+    def test_set_f1_perfect_match(self):
+        scorer = SetF1Scorer()
+        assert scorer.score("Final Answer: [A, B, C]", ["A", "B", "C"]) == 1.0
+
+    def test_set_f1_partial_match(self):
+        scorer = SetF1Scorer()
+        # predicted: {A, B}, truth: {A, B, C}
+        # precision = 2/2 = 1.0, recall = 2/3, f1 = 2*(1*2/3)/(1+2/3) = 4/5 = 0.8
+        score = scorer.score("Final Answer: [A, B]", ["A", "B", "C"])
+        assert abs(score - 0.8) < 1e-9
+
+    def test_set_f1_no_match(self):
+        scorer = SetF1Scorer()
+        assert scorer.score("Final Answer: [X]", ["A", "B"]) == 0.0
+
+    def test_set_f1_empty_prediction(self):
+        scorer = SetF1Scorer()
+        # No Final Answer format → empty set → score 0
+        assert scorer.score("The answer is B", ["B"]) == 0.0
+
+    def test_set_f1_empty_reference(self):
+        scorer = SetF1Scorer()
+        # Both empty → 1.0 (vacuously correct)
+        assert scorer.score("Final Answer: []", []) == 1.0
+
+    def test_set_f1_nonempty_prediction_empty_reference(self):
+        scorer = SetF1Scorer()
+        # When ground truth is empty, the official HF scorer returns 1.0 (vacuously
+        # correct: recall+precision==0 and n_golden==0).
+        assert scorer.score("Final Answer: [A]", []) == 1.0
+
+    # ------------------------------------------------------------------
+    # MockJudge tests
+    # ------------------------------------------------------------------
 
     def test_mock_judge_non_empty(self):
         judge = MockJudge()
-        assert judge.score("some answer", "reference") == 1.0
+        assert judge.score("some answer", ["reference"]) == 1.0
 
     def test_mock_judge_empty(self):
         judge = MockJudge()
-        assert judge.score("", "reference") == 0.0
-        assert judge.score("   ", "reference") == 0.0
+        assert judge.score("", ["reference"]) == 0.0
+        assert judge.score("   ", ["reference"]) == 0.0
+
+    # ------------------------------------------------------------------
+    # Synthetic question answer format test
+    # ------------------------------------------------------------------
+
+    def test_synthetic_answer_is_list(self):
+        """Synthetic questions must produce list answers for SetF1Scorer."""
+        q = generate_synthetic_question(num_nodes=5, num_hops=2, seed=0)
+        assert isinstance(q["answer"], list), "answer must be a list[str]"
+        assert len(q["answer"]) >= 1
+        assert all(isinstance(n, str) for n in q["answer"])
+
+    def test_synthetic_answer_in_final_answer_format(self):
+        """A response formatted as Final Answer: [...] should score > 0 for synthetic q."""
+        scorer = SetF1Scorer()
+        q = generate_synthetic_question(num_nodes=5, num_hops=2, seed=0)
+        answer_node = q["answer"][0]
+        response = f"Final Answer: [{answer_node}]"
+        assert scorer.score(response, q["answer"]) == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +377,7 @@ class TestRunnerDryRun:
     def _make_runner(
         self,
         tmp_snapshot_dir: Path,
-        answer: str = "node B",
+        answer: str = "Final Answer: [B]",
         scorer=None,
     ) -> GraphWalksRunner:
         client = MagicMock()


### PR DESCRIPTION
## Summary

Replaces the LLM-based judge (GPT4oJudge, ExactMatchScorer) with the correct, verified scoring method from the openai/graphwalks HF dataset card.

- Introduces `SetF1Scorer` and `parse_answer` in `judge.py` — purely programmatic, no API key needed
- Updates runner prompts to elicit `Final Answer: [node1, node2, ...]` format
- Wraps synthetic question answers as `list[str]` to match scorer contract
- Adds `conftest.py` so tests can be run from any directory
- 41 tests passing, zero GPT4o calls

## Scoring method

**Official method (verified against openai/graphwalks HF dataset card):**
Purely programmatic — no LLM judge.

Set-overlap F1 over node sets. Models must end responses with `Final Answer: [node1, node2, ...]`. Answers not in this format score 0.

```python
precision = |predicted ∩ truth| / |predicted|
recall    = |predicted ∩ truth| / |truth|
f1        = 2 * precision * recall / (precision + recall)
```

Applies to both task types (BFS, Parents). No `OPENAI_API_KEY` required.

## Test plan

- [ ] `python -m pytest benchmark/graphwalks/test_dry_run.py -v` passes (41 tests)
- [ ] Confirm no `OPENAI_API_KEY` is required for any scoring path
- [ ] Verify `parse_answer` correctly handles missing/malformed `Final Answer:` lines (scores 0)
- [ ] Verify `SetF1Scorer` partial-match F1 arithmetic against HF dataset card formula





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26322501374](https://github.com/Clarit-AI/Engram/actions/runs/26322501374)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26322502732](https://github.com/Clarit-AI/Engram/actions/runs/26322502732)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->