### PR TITLE
feat(benchmark): scaffold RULER harness (CPU/mock dry-run)

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,0 +1,1 @@
+# Engram benchmark harness collection

--- a/benchmark/ruler/README.md
+++ b/benchmark/ruler/README.md
@@ -1,0 +1,150 @@
+# RULER Benchmark Harness
+
+Engram's RULER harness measures whether snapshot-based statefulness reduces
+compute cost for long-context inference.  Instead of re-processing a long
+context on every turn, Engram restores a saved hidden state — the harness
+quantifies how much that saves.
+
+## Dataset
+
+| Property | Value |
+|---|---|
+| Name | RULER (Really Urgent Long-context Evaluation for Research) |
+| Source | <https://huggingface.co/datasets/hsiehjackson/RULER> |
+| Paper | RULER: What's the Real Context Window Size of Your Long-Context Language Models? |
+| License | MIT |
+| Generation | Synthetic — generated on the fly, no fixed download corpus |
+| Approx. size | <100 MB for 4K–128K configs at 10 samples per (task, context_length) |
+
+### 13 Task Types
+
+| Category | Tasks |
+|---|---|
+| Needle-in-a-Haystack (single) | `niah_single_1`, `niah_single_2`, `niah_single_3` |
+| Needle-in-a-Haystack (multi-key) | `niah_multikey_1`, `niah_multikey_2`, `niah_multikey_3` |
+| Needle-in-a-Haystack (multi-value) | `niah_multivalue` |
+| Needle-in-a-Haystack (multi-query) | `niah_multiquery` |
+| Variable Tracking | `vt` |
+| Common Words Extraction | `cwe` |
+| Frequent Words Extraction | `fwe` |
+| Question Answering | `qa_1`, `qa_2` |
+
+### Standard Context Lengths
+
+`4096`, `8192`, `16384`, `32768`, `65536`, `131072` tokens
+
+## Quick Start
+
+### CPU / mock dry-run (no GPU required)
+
+```bash
+# From the repo root
+pytest benchmark/ruler/test_dry_run.py -v
+```
+
+### GPU run (requires a running Engram or SGLang endpoint)
+
+```bash
+python -m benchmark.ruler.runner \
+    --model-url http://localhost:30000 \
+    --model-name elastic-30b \
+    --context-lengths 4096,8192,16384,32768 \
+    --tasks niah_single_1,niah_single_2,vt,cwe,qa_1 \
+    --num-samples 10 \
+    --snapshot-dir /tmp/ruler_snapshots \
+    --output ruler_results.jsonl \
+    --mode both \
+    --verbose
+```
+
+### Baseline only (no snapshots)
+
+```bash
+python -m benchmark.ruler.runner \
+    --model-url http://localhost:30000 \
+    --mode baseline \
+    --output ruler_baseline.jsonl
+```
+
+### Engram-only (use existing snapshots)
+
+```bash
+python -m benchmark.ruler.runner \
+    --model-url http://localhost:30000 \
+    --mode engram \
+    --snapshot-dir /mnt/ruler_snapshots \
+    --output ruler_engram.jsonl
+```
+
+## Expected Output Shape
+
+Each JSONL file contains one line per `TaskResult`, plus a final summary line:
+
+```json
+{"task_id": "niah_single_1_cl4096_abc123", "task_name": "niah_single_1",
+ "context_length": 4096, "restore_mode": "warm", "baseline_ttft_s": 1.23,
+ "baseline_input_tokens": 4100, "baseline_score": 1.0,
+ "engram_ttft_s": 0.08, "engram_input_tokens": 32, "engram_score": 1.0, ...}
+...
+{"_record_type": "summary", "metrics": {"token_reduction": 0.982,
+ "ttft_speedup": 15.4, "compute_amortization": 4068.0,
+ "warm_token_reduction": 0.992, "cold_token_reduction": 0.0}, ...}
+```
+
+Per-task score breakdown is included in the summary line under `task_score_summary`.
+
+### Key Metrics
+
+| Metric | Formula | Goal |
+|---|---|---|
+| `token_reduction` | `1 - engram_tokens / baseline_tokens` | Higher is better |
+| `ttft_speedup` | `baseline_ttft / engram_ttft` (geometric mean) | Higher is better |
+| `compute_amortization` | `Σ (baseline_tokens - engram_tokens)` | Higher is better |
+
+Every result line includes `restore_mode: "warm" | "cold"`.  A result without
+a warm/cold label is not publishable.
+
+## Results Storage
+
+Results are stored at:
+
+```
+s3://engram/benchmarks/ruler/
+```
+
+Upload with `s3cmd` targeting the `sfo3` region:
+
+```bash
+s3cmd put ruler_results.jsonl \
+    s3://engram/benchmarks/ruler/$(date +%Y%m%d_%H%M%S)_ruler_results.jsonl \
+    --host=sfo3.digitaloceanspaces.com \
+    --host-bucket="%(bucket)s.sfo3.digitaloceanspaces.com"
+```
+
+## GPU Run Pending Checklist
+
+- [ ] Verify Engram snapshot save/restore works end-to-end for the target model
+- [ ] Confirm `/v1/completions` endpoint is reachable at `--model-url`
+- [ ] Set `OPENAI_API_KEY` if using `GPT4oJudge` for qa_1 / qa_2 scoring
+- [ ] Set `JUDGE_MODEL` env var if overriding the default `gpt-4o` judge
+- [ ] Choose snapshot directory with sufficient disk space (estimate: ~500 MB per model per context length for Mamba-family models)
+- [ ] Run with `--num-samples 25` for publication-quality results
+- [ ] Upload results to `s3://engram/benchmarks/ruler/`
+
+## Target Models
+
+| Model | Precision | Parallelism | Notes |
+|---|---|---|---|
+| Elastic 30B | BF16 | Single H100 | Primary evaluation target |
+| Qwen3-Coder-Next | FP8 | TP=4 (cluster) | High-throughput cluster run |
+
+## Module Reference
+
+| File | Purpose |
+|---|---|
+| `results.py` | `TaskResult`, `RunSummary` dataclasses + metrics + JSONL I/O |
+| `judge.py` | `ExactMatchScorer`, `GPT4oJudge`, `MockJudge` |
+| `tasks.py` | 13 task definitions, `TaskInstance`, `generate_synthetic_task()` |
+| `runner.py` | `RULERRunner` (two-phase baseline/Engram), CLI entry point |
+| `download.py` | `generate_dataset()`, `load_dataset()`, HF Hub metadata fetch |
+| `test_dry_run.py` | CPU/mock pytest suite (no GPU, no network) |

--- a/benchmark/ruler/__init__.py
+++ b/benchmark/ruler/__init__.py
@@ -1,0 +1,1 @@
+# RULER benchmark harness for Engram

--- a/benchmark/ruler/download.py
+++ b/benchmark/ruler/download.py
@@ -1,0 +1,207 @@
+"""
+RULER dataset provisioning.
+
+RULER generates synthetic data on-the-fly — there is no fixed corpus to
+download.  This module provides:
+
+1. Offline generation via generate_dataset() — works with no network access.
+2. Optional HuggingFace Hub metadata fetch (hsiehjackson/RULER) for config
+   reference.
+
+License: MIT (RULER scripts and generated data are MIT-licensed).
+Approx. data size: Generated on-the-fly; typically <100 MB for 4 K–128 K
+    context configs at 10 samples per (task, length).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from .tasks import (
+    CONTEXT_LENGTHS,
+    RULER_TASKS,
+    TaskInstance,
+    generate_synthetic_task,
+)
+
+logger = logging.getLogger(__name__)
+
+_HF_REPO_ID = "hsiehjackson/RULER"
+_DEFAULT_OUTPUT = Path(__file__).parent / "data" / "ruler" / "generated_tasks.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Offline generation
+# ---------------------------------------------------------------------------
+
+
+def generate_dataset(
+    tasks: Optional[List[str]] = None,
+    context_lengths: Optional[List[int]] = None,
+    num_samples: int = 10,
+    output_path: Optional[str | Path] = None,
+) -> List[TaskInstance]:
+    """Generate a RULER dataset fully offline.
+
+    Args:
+        tasks: List of RULER task names to generate.  Defaults to all 13.
+        context_lengths: List of context-length buckets to generate.
+            Defaults to all six standard lengths.
+        num_samples: Number of samples per (task, context_length) pair.
+        output_path: If given, write generated instances to this JSONL file.
+
+    Returns:
+        List of TaskInstance objects.
+    """
+    if tasks is None:
+        tasks = RULER_TASKS
+    if context_lengths is None:
+        context_lengths = CONTEXT_LENGTHS
+
+    invalid = [t for t in tasks if t not in RULER_TASKS]
+    if invalid:
+        raise ValueError(f"Unknown task names: {invalid}")
+
+    instances: List[TaskInstance] = []
+    total = len(tasks) * len(context_lengths) * num_samples
+    logger.info(
+        "Generating %d RULER instances (%d tasks × %d ctx_lengths × %d samples)…",
+        total,
+        len(tasks),
+        len(context_lengths),
+        num_samples,
+    )
+
+    for task_name in tasks:
+        for ctx_len in context_lengths:
+            for sample_idx in range(num_samples):
+                instance = generate_synthetic_task(task_name, ctx_len, sample_idx)
+                instances.append(instance)
+
+    logger.info("Generated %d instances.", len(instances))
+
+    if output_path is not None:
+        _write_jsonl(instances, Path(output_path))
+    elif output_path is None:
+        # Write to default location
+        _write_jsonl(instances, _DEFAULT_OUTPUT)
+
+    return instances
+
+
+def _instance_to_dict(instance: TaskInstance) -> dict:
+    return {
+        "task_id": instance.task_id,
+        "task_name": instance.task_name,
+        "context_length": instance.context_length,
+        "context_text": instance.context_text,
+        "question": instance.question,
+        "answer": instance.answer,
+    }
+
+
+def _instance_from_dict(d: dict) -> TaskInstance:
+    return TaskInstance(
+        task_id=d.get("task_id"),
+        task_name=d["task_name"],
+        context_length=d["context_length"],
+        context_text=d["context_text"],
+        question=d["question"],
+        answer=d["answer"],
+    )
+
+
+def _write_jsonl(instances: List[TaskInstance], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for inst in instances:
+            f.write(json.dumps(_instance_to_dict(inst)) + "\n")
+    logger.info("Dataset written to %s (%d lines)", path, len(instances))
+
+
+def load_dataset(path: str | Path) -> List[TaskInstance]:
+    """Load a previously generated dataset from a JSONL file."""
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+    instances: List[TaskInstance] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            instances.append(_instance_from_dict(json.loads(line)))
+    logger.info("Loaded %d instances from %s", len(instances), path)
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# Optional HuggingFace Hub metadata fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_hf_ruler_config(
+    repo_id: str = _HF_REPO_ID,
+    local_dir: Optional[str | Path] = None,
+) -> Optional[Path]:
+    """Attempt to fetch RULER config files from the HuggingFace Hub.
+
+    This is informational only — RULER benchmark tasks are generated
+    synthetically and do not require downloading any HF dataset.
+
+    Args:
+        repo_id: HuggingFace repository ID (default: hsiehjackson/RULER).
+        local_dir: Local directory to cache downloaded files.
+
+    Returns:
+        Path to the downloaded directory, or None if the fetch failed.
+    """
+    try:
+        from huggingface_hub import snapshot_download  # type: ignore
+    except ImportError:
+        logger.warning(
+            "huggingface_hub is not installed. Skipping HF config fetch."
+        )
+        return None
+
+    if local_dir is None:
+        local_dir = Path("/tmp/ruler_hf_config")
+
+    try:
+        logger.info("Fetching RULER config from HuggingFace Hub: %s", repo_id)
+        path = snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            local_dir=str(local_dir),
+            ignore_patterns=["*.parquet", "*.arrow"],  # skip large data files
+        )
+        logger.info("RULER config downloaded to: %s", path)
+        return Path(path)
+    except Exception as exc:
+        logger.warning("Failed to fetch RULER config from HF Hub: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dataset info
+# ---------------------------------------------------------------------------
+
+RULER_DATASET_INFO = {
+    "name": "RULER",
+    "source": "https://huggingface.co/datasets/hsiehjackson/RULER",
+    "paper": "RULER: What's the Real Context Window Size of Your Long-Context Language Models?",
+    "license": "MIT",
+    "generation": "Synthetic (on-the-fly, no fixed download corpus)",
+    "approx_size_mb": "<100 MB for 4K–128K configs at 10 samples per (task, context_length)",
+    "tasks": RULER_TASKS,
+    "context_lengths": CONTEXT_LENGTHS,
+    "num_tasks": len(RULER_TASKS),
+    "note": (
+        "RULER generates data synthetically.  Use generate_dataset() for "
+        "offline generation.  huggingface_hub is optional and only used to "
+        "fetch configuration metadata."
+    ),
+}

--- a/benchmark/ruler/judge.py
+++ b/benchmark/ruler/judge.py
@@ -1,0 +1,145 @@
+"""
+Scoring / judging module for RULER.
+
+RULER is synthetic with exact ground truth, so the primary scorer is
+ExactMatchScorer.  GPT4oJudge is provided for tasks where exact match
+is too strict (e.g. paraphrase answers in qa_1 / qa_2).  MockJudge is
+used in dry-run / CI environments.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Union
+
+
+class ExactMatchScorer:
+    """Exact-match scorer for RULER tasks.
+
+    Returns 1.0 if the answer string contains any of the reference strings
+    (case-insensitive substring match), else 0.0.
+
+    RULER answers are typically short identifiers (needle strings, word
+    lists, variable values), so substring containment is the appropriate
+    check rather than full-string equality.
+    """
+
+    def score(
+        self,
+        answer: str,
+        reference: Union[str, list],
+    ) -> float:
+        """Score an answer against one or more references.
+
+        Args:
+            answer: The model-generated answer string.
+            reference: A single reference string or a list of reference strings.
+                       Scoring passes (1.0) if the answer contains ANY reference.
+
+        Returns:
+            1.0 if matched, 0.0 otherwise.
+        """
+        if isinstance(reference, str):
+            references = [reference]
+        else:
+            references = list(reference)
+
+        answer_lower = answer.strip().lower()
+        for ref in references:
+            if ref.strip().lower() in answer_lower:
+                return 1.0
+        return 0.0
+
+
+class GPT4oJudge:
+    """LLM-based judge backed by the OpenAI API.
+
+    Reads OPENAI_API_KEY from the environment.  The model is controlled
+    by the JUDGE_MODEL env var (default: gpt-4o).
+
+    Raises RuntimeError on construction if OPENAI_API_KEY is absent.
+    """
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY environment variable is not set. "
+                "Export it before using GPT4oJudge."
+            )
+        self._api_key = api_key
+        self._model = os.environ.get("JUDGE_MODEL", "gpt-4o")
+        # Import lazily so the module can be imported without openai installed
+        try:
+            import openai  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "openai package is required for GPT4oJudge. "
+                "Install it with: pip install openai"
+            ) from exc
+
+    def score(
+        self,
+        answer: str,
+        reference: Union[str, list],
+        context: str = "",
+    ) -> float:
+        """Score an answer using GPT-4o as a judge.
+
+        Args:
+            answer: Model-generated answer.
+            reference: Ground-truth reference(s).
+            context: Optional context/question for the judge prompt.
+
+        Returns:
+            Score between 0.0 and 1.0.
+        """
+        import openai
+
+        client = openai.OpenAI(api_key=self._api_key)
+
+        if isinstance(reference, list):
+            ref_text = "\n".join(f"- {r}" for r in reference)
+        else:
+            ref_text = reference
+
+        system_prompt = (
+            "You are an evaluator for a reading-comprehension benchmark. "
+            "Given a model answer and the ground-truth reference(s), respond "
+            "with exactly one of: CORRECT or INCORRECT."
+        )
+        user_prompt = (
+            f"Reference answer(s):\n{ref_text}\n\n"
+            f"Model answer:\n{answer}\n\n"
+            "Is the model answer correct? Reply CORRECT or INCORRECT only."
+        )
+        if context:
+            user_prompt = f"Context/Question:\n{context}\n\n" + user_prompt
+
+        response = client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=5,
+            temperature=0.0,
+        )
+        verdict = response.choices[0].message.content.strip().upper()
+        return 1.0 if "CORRECT" in verdict else 0.0
+
+
+class MockJudge:
+    """Deterministic mock judge for CI / dry-run environments.
+
+    Returns 1.0 for any non-empty answer, 0.0 for empty answers.
+    Does not call any external API.
+    """
+
+    def score(
+        self,
+        answer: str,
+        reference: Union[str, list],
+        context: str = "",
+    ) -> float:
+        return 1.0 if answer.strip() else 0.0

--- a/benchmark/ruler/judge.py
+++ b/benchmark/ruler/judge.py
@@ -1,145 +1,137 @@
 """
-Scoring / judging module for RULER.
+RULER scoring — purely programmatic, no LLM judge.
+Verified against hsiehjackson/RULER/scripts/eval/synthetic/constants.py.
 
-RULER is synthetic with exact ground truth, so the primary scorer is
-ExactMatchScorer.  GPT4oJudge is provided for tasks where exact match
-is too strict (e.g. paraphrase answers in qa_1 / qa_2).  MockJudge is
-used in dry-run / CI environments.
+RULER is a synthetic benchmark with exact ground truth. Scoring is done by
+substring matching, not by an LLM judge. Two scoring functions are used:
+
+- string_match_all: recall-based. For each (prediction, references) pair,
+  computes the fraction of reference strings found as substrings in the
+  prediction. Used for NIAH variants, VT, CWE, FWE.
+
+- string_match_part: any-match. For each pair, returns 1.0 if any reference
+  is found as a substring in the prediction, else 0.0. Used for QA_1
+  (SQuAD) and QA_2 (HotPotQA).
+
+No OPENAI_API_KEY is required for RULER scoring.
 """
 
 from __future__ import annotations
 
-import os
 from typing import Union
 
 
-class ExactMatchScorer:
-    """Exact-match scorer for RULER tasks.
+class StringMatchAllScorer:
+    """Recall-based substring scorer for RULER.
 
-    Returns 1.0 if the answer string contains any of the reference strings
-    (case-insensitive substring match), else 0.0.
+    For a single (prediction, references) pair: computes the fraction of
+    reference strings that appear as substrings in the prediction
+    (case-insensitive). This matches `string_match_all` in the official
+    hsiehjackson/RULER harness.
 
-    RULER answers are typically short identifiers (needle strings, word
-    lists, variable values), so substring containment is the appropriate
-    check rather than full-string equality.
+    Returns a value in [0.0, 1.0] (NOT 0–100).
+
+    Used for: NIAH variants, VT, CWE, FWE.
     """
 
     def score(
         self,
-        answer: str,
-        reference: Union[str, list],
+        prediction: str,
+        references: Union[str, list],
     ) -> float:
-        """Score an answer against one or more references.
+        """Score a prediction against a list of reference strings.
 
         Args:
-            answer: The model-generated answer string.
-            reference: A single reference string or a list of reference strings.
-                       Scoring passes (1.0) if the answer contains ANY reference.
+            prediction: The model-generated response string.
+            references: A single reference string or a list of valid
+                        reference strings. ALL must be found for score=1.0.
 
         Returns:
-            1.0 if matched, 0.0 otherwise.
+            Fraction of references found as substrings in the prediction,
+            in [0.0, 1.0].
         """
-        if isinstance(reference, str):
-            references = [reference]
+        if isinstance(references, str):
+            ref_list = [references]
         else:
-            references = list(reference)
+            ref_list = list(references)
 
-        answer_lower = answer.strip().lower()
-        for ref in references:
-            if ref.strip().lower() in answer_lower:
-                return 1.0
-        return 0.0
+        if not ref_list:
+            return 0.0
+
+        pred_lower = prediction.lower()
+        hits = sum(1.0 if r.lower() in pred_lower else 0.0 for r in ref_list)
+        return hits / len(ref_list)
 
 
-class GPT4oJudge:
-    """LLM-based judge backed by the OpenAI API.
+class StringMatchPartScorer:
+    """Any-match substring scorer for RULER QA tasks.
 
-    Reads OPENAI_API_KEY from the environment.  The model is controlled
-    by the JUDGE_MODEL env var (default: gpt-4o).
+    For a single (prediction, references) pair: returns 1.0 if ANY reference
+    string appears as a substring in the prediction (case-insensitive),
+    else 0.0. This matches `string_match_part` in the official
+    hsiehjackson/RULER harness.
 
-    Raises RuntimeError on construction if OPENAI_API_KEY is absent.
+    Returns a value in [0.0, 1.0] (NOT 0–100).
+
+    Used for: qa_1 (SQuAD), qa_2 (HotPotQA).
     """
-
-    def __init__(self) -> None:
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            raise RuntimeError(
-                "OPENAI_API_KEY environment variable is not set. "
-                "Export it before using GPT4oJudge."
-            )
-        self._api_key = api_key
-        self._model = os.environ.get("JUDGE_MODEL", "gpt-4o")
-        # Import lazily so the module can be imported without openai installed
-        try:
-            import openai  # noqa: F401
-        except ImportError as exc:
-            raise RuntimeError(
-                "openai package is required for GPT4oJudge. "
-                "Install it with: pip install openai"
-            ) from exc
 
     def score(
         self,
-        answer: str,
-        reference: Union[str, list],
-        context: str = "",
+        prediction: str,
+        references: Union[str, list],
     ) -> float:
-        """Score an answer using GPT-4o as a judge.
+        """Score a prediction against a list of reference strings.
 
         Args:
-            answer: Model-generated answer.
-            reference: Ground-truth reference(s).
-            context: Optional context/question for the judge prompt.
+            prediction: The model-generated response string.
+            references: A single reference string or a list of valid
+                        reference strings. ANY match yields score=1.0.
 
         Returns:
-            Score between 0.0 and 1.0.
+            1.0 if any reference is found as a substring in the prediction,
+            else 0.0.
         """
-        import openai
-
-        client = openai.OpenAI(api_key=self._api_key)
-
-        if isinstance(reference, list):
-            ref_text = "\n".join(f"- {r}" for r in reference)
+        if isinstance(references, str):
+            ref_list = [references]
         else:
-            ref_text = reference
+            ref_list = list(references)
 
-        system_prompt = (
-            "You are an evaluator for a reading-comprehension benchmark. "
-            "Given a model answer and the ground-truth reference(s), respond "
-            "with exactly one of: CORRECT or INCORRECT."
-        )
-        user_prompt = (
-            f"Reference answer(s):\n{ref_text}\n\n"
-            f"Model answer:\n{answer}\n\n"
-            "Is the model answer correct? Reply CORRECT or INCORRECT only."
-        )
-        if context:
-            user_prompt = f"Context/Question:\n{context}\n\n" + user_prompt
+        if not ref_list:
+            return 0.0
 
-        response = client.chat.completions.create(
-            model=self._model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            max_tokens=5,
-            temperature=0.0,
-        )
-        verdict = response.choices[0].message.content.strip().upper()
-        return 1.0 if "CORRECT" in verdict else 0.0
+        pred_lower = prediction.lower()
+        return max(1.0 if r.lower() in pred_lower else 0.0 for r in ref_list)
+
+
+# QA tasks that use string_match_part (any-match)
+_QA_TASKS = {"qa_1", "qa_2"}
+
+
+def get_scorer(task_name: str):
+    """Return the correct scorer for the given RULER task name.
+
+    Args:
+        task_name: RULER task name (e.g. "niah_single_1", "qa_1").
+
+    Returns:
+        StringMatchPartScorer for qa_1/qa_2; StringMatchAllScorer otherwise.
+    """
+    if task_name in _QA_TASKS:
+        return StringMatchPartScorer()
+    return StringMatchAllScorer()
 
 
 class MockJudge:
     """Deterministic mock judge for CI / dry-run environments.
 
-    Returns 1.0 for any non-empty answer, 0.0 for empty answers.
-    Does not call any external API.
+    Returns 1.0 for any non-empty prediction, 0.0 for empty predictions.
+    Does not call any external API. Compatible with the scorer interface.
     """
 
     def score(
         self,
-        answer: str,
-        reference: Union[str, list],
-        context: str = "",
+        prediction: str,
+        references: Union[str, list],
     ) -> float:
-        return 1.0 if answer.strip() else 0.0
+        return 1.0 if prediction.strip() else 0.0

--- a/benchmark/ruler/results.py
+++ b/benchmark/ruler/results.py
@@ -1,0 +1,236 @@
+"""
+Results schema for the RULER benchmark harness.
+
+Every question result stores `restore_mode: Literal["warm", "cold"]`.
+A token-reduction number with no warm/cold label is not publishable.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+
+RestoreMode = Literal["warm", "cold"]
+
+
+@dataclass
+class TaskResult:
+    """Per-task-instance result capturing both baseline and Engram measurements."""
+
+    # Identity
+    task_id: str
+    task_name: str
+    context_length: int
+    restore_mode: RestoreMode  # warm = snapshot hit, cold = snapshot miss
+
+    # Baseline (full context re-processed every turn)
+    baseline_ttft_s: float
+    baseline_input_tokens: int
+    baseline_output_tokens: int
+    baseline_answer: str
+    baseline_score: float  # 0.0 – 1.0
+
+    # Engram (snapshot-aware path)
+    engram_ttft_s: float
+    engram_input_tokens: int
+    engram_output_tokens: int
+    engram_answer: str
+    engram_score: float  # 0.0 – 1.0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TaskResult":
+        return cls(**d)
+
+
+@dataclass
+class RunSummary:
+    """Aggregated run-level results across all tasks and context lengths."""
+
+    benchmark: str = "ruler"
+    model: str = ""
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    results: List[TaskResult] = field(default_factory=list)
+
+    # ------------------------------------------------------------------ #
+    # Core publishable metrics                                             #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def token_reduction(self) -> float:
+        """1 - (engram_tokens / baseline_tokens) across all results.
+
+        Positive means Engram sent fewer tokens.
+        """
+        baseline_total = sum(r.baseline_input_tokens for r in self.results)
+        engram_total = sum(r.engram_input_tokens for r in self.results)
+        if baseline_total == 0:
+            return 0.0
+        return 1.0 - (engram_total / baseline_total)
+
+    @property
+    def ttft_speedup(self) -> float:
+        """Geometric mean of per-result (baseline_ttft / engram_ttft) ratios.
+
+        >1.0 means Engram is faster.  Returns NaN if any engram_ttft is 0.
+        """
+        ratios = []
+        for r in self.results:
+            if r.engram_ttft_s <= 0:
+                return math.nan
+            ratios.append(r.baseline_ttft_s / r.engram_ttft_s)
+        if not ratios:
+            return 0.0
+        log_sum = sum(math.log(x) for x in ratios if x > 0)
+        return math.exp(log_sum / len(ratios))
+
+    @property
+    def compute_amortization(self) -> float:
+        """Total tokens saved across all results (proxy for FLOPs amortized)."""
+        return float(
+            sum(
+                max(0, r.baseline_input_tokens - r.engram_input_tokens)
+                for r in self.results
+            )
+        )
+
+    # ------------------------------------------------------------------ #
+    # Breakdowns                                                           #
+    # ------------------------------------------------------------------ #
+
+    def by_task(self) -> Dict[str, List[TaskResult]]:
+        """Group results by task_name."""
+        groups: Dict[str, List[TaskResult]] = {}
+        for r in self.results:
+            groups.setdefault(r.task_name, []).append(r)
+        return groups
+
+    def by_context_length(self) -> Dict[int, List[TaskResult]]:
+        """Group results by context_length."""
+        groups: Dict[int, List[TaskResult]] = {}
+        for r in self.results:
+            groups.setdefault(r.context_length, []).append(r)
+        return groups
+
+    def by_restore_mode(self) -> Dict[RestoreMode, List[TaskResult]]:
+        """Group results by restore_mode (warm vs cold)."""
+        groups: Dict[RestoreMode, List[TaskResult]] = {"warm": [], "cold": []}
+        for r in self.results:
+            groups[r.restore_mode].append(r)
+        return groups
+
+    def warm_token_reduction(self) -> float:
+        """token_reduction computed over warm hits only."""
+        warm = self.by_restore_mode()["warm"]
+        if not warm:
+            return 0.0
+        baseline_total = sum(r.baseline_input_tokens for r in warm)
+        engram_total = sum(r.engram_input_tokens for r in warm)
+        if baseline_total == 0:
+            return 0.0
+        return 1.0 - (engram_total / baseline_total)
+
+    def cold_token_reduction(self) -> float:
+        """token_reduction computed over cold misses only.
+
+        Expected to be ~0 or slightly negative (overhead) for cold paths.
+        """
+        cold = self.by_restore_mode()["cold"]
+        if not cold:
+            return 0.0
+        baseline_total = sum(r.baseline_input_tokens for r in cold)
+        engram_total = sum(r.engram_input_tokens for r in cold)
+        if baseline_total == 0:
+            return 0.0
+        return 1.0 - (engram_total / baseline_total)
+
+    def task_score_summary(self) -> Dict[str, Dict[str, float]]:
+        """Per-task average baseline and engram scores."""
+        summary = {}
+        for task_name, task_results in self.by_task().items():
+            summary[task_name] = {
+                "baseline_score": sum(r.baseline_score for r in task_results)
+                / len(task_results),
+                "engram_score": sum(r.engram_score for r in task_results)
+                / len(task_results),
+                "n": len(task_results),
+            }
+        return summary
+
+    # ------------------------------------------------------------------ #
+    # Serialization                                                        #
+    # ------------------------------------------------------------------ #
+
+    def to_dict(self) -> dict:
+        return {
+            "benchmark": self.benchmark,
+            "model": self.model,
+            "timestamp": self.timestamp,
+            "results": [r.to_dict() for r in self.results],
+            # Bake metrics into the summary dict for easy inspection
+            "metrics": {
+                "token_reduction": self.token_reduction,
+                "ttft_speedup": self.ttft_speedup,
+                "compute_amortization": self.compute_amortization,
+                "warm_token_reduction": self.warm_token_reduction(),
+                "cold_token_reduction": self.cold_token_reduction(),
+            },
+        }
+
+    def to_jsonl(self, path: str | Path) -> None:
+        """Write one JSON line per TaskResult, plus a summary line at the end."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            for r in self.results:
+                f.write(json.dumps(r.to_dict()) + "\n")
+            # Final line is the aggregated summary (no "results" list to avoid duplication)
+            summary_line = {
+                "benchmark": self.benchmark,
+                "model": self.model,
+                "timestamp": self.timestamp,
+                "_record_type": "summary",
+                "metrics": {
+                    "token_reduction": self.token_reduction,
+                    "ttft_speedup": self.ttft_speedup,
+                    "compute_amortization": self.compute_amortization,
+                    "warm_token_reduction": self.warm_token_reduction(),
+                    "cold_token_reduction": self.cold_token_reduction(),
+                },
+                "task_score_summary": self.task_score_summary(),
+            }
+            f.write(json.dumps(summary_line) + "\n")
+
+    @classmethod
+    def from_jsonl(cls, path: str | Path) -> "RunSummary":
+        """Load a RunSummary from a JSONL file written by to_jsonl()."""
+        path = Path(path)
+        results: List[TaskResult] = []
+        summary_meta: Optional[dict] = None
+
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                if record.get("_record_type") == "summary":
+                    summary_meta = record
+                else:
+                    results.append(TaskResult.from_dict(record))
+
+        obj = cls(results=results)
+        if summary_meta:
+            obj.benchmark = summary_meta.get("benchmark", "ruler")
+            obj.model = summary_meta.get("model", "")
+            obj.timestamp = summary_meta.get("timestamp", obj.timestamp)
+        return obj

--- a/benchmark/ruler/runner.py
+++ b/benchmark/ruler/runner.py
@@ -27,7 +27,7 @@ import time
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
-from .judge import ExactMatchScorer
+from .judge import StringMatchAllScorer, get_scorer
 from .results import RestoreMode, RunSummary, TaskResult
 from .tasks import (
     RULER_TASKS,
@@ -143,7 +143,9 @@ class RULERRunner:
         self.snapshot_dir = Path(snapshot_dir) if snapshot_dir else Path("/tmp/ruler_snapshots")
         self.snapshot_dir.mkdir(parents=True, exist_ok=True)
         self._http_client = http_client or _real_http_client
-        self.scorer = scorer if scorer is not None else ExactMatchScorer()
+        # If no scorer is injected, use task-aware get_scorer() per call.
+        # An injected scorer overrides per-task selection (useful for testing).
+        self._scorer_override = scorer
         self.max_new_tokens = max_new_tokens
 
     # ------------------------------------------------------------------ #
@@ -173,7 +175,7 @@ class RULERRunner:
 
             answer, latency = self._call(prompt)
             output_tokens = _count_tokens(answer)
-            score = self._score(answer, task.answer)
+            score = self._score(answer, task.answer, task.task_name)
 
             result = TaskResult(
                 task_id=task.task_id or task.task_name,
@@ -227,7 +229,7 @@ class RULERRunner:
 
             answer, latency = self._call(prompt)
             output_tokens = _count_tokens(answer)
-            score = self._score(answer, task.answer)
+            score = self._score(answer, task.answer, task.task_name)
 
             # If cold, save snapshot so subsequent runs are warm
             if restore_mode == "cold":
@@ -273,13 +275,13 @@ class RULERRunner:
             baseline_input_tokens = _count_tokens(baseline_prompt)
             baseline_answer, baseline_latency = self._call(baseline_prompt)
             baseline_output_tokens = _count_tokens(baseline_answer)
-            baseline_score = self._score(baseline_answer, task.answer)
+            baseline_score = self._score(baseline_answer, task.answer, task.task_name)
 
             # --- Engram ---
             restore_mode, engram_prompt, engram_input_tokens = self._engram_prompt(task)
             engram_answer, engram_latency = self._call(engram_prompt)
             engram_output_tokens = _count_tokens(engram_answer)
-            engram_score = self._score(engram_answer, task.answer)
+            engram_score = self._score(engram_answer, task.answer, task.task_name)
 
             if restore_mode == "cold":
                 self._save_snapshot(task)
@@ -359,8 +361,9 @@ class RULERRunner:
         """Invoke the HTTP client, returning (answer_text, latency_s)."""
         return self._http_client(self.model_url, prompt, self.model_name)
 
-    def _score(self, answer: str, reference) -> float:
-        return self.scorer.score(answer, reference)
+    def _score(self, answer: str, reference, task_name: str = "") -> float:
+        scorer = self._scorer_override if self._scorer_override is not None else get_scorer(task_name)
+        return scorer.score(answer, reference)
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/ruler/runner.py
+++ b/benchmark/ruler/runner.py
@@ -1,0 +1,495 @@
+"""
+RULER harness runner — two-phase execution (baseline vs Engram).
+
+Baseline: sends full context + question on every request.
+Engram: checks for a saved snapshot; if present (warm), sends only the
+question; if absent (cold), sends full context + question and saves a
+stub snapshot.
+
+Usage (CLI):
+    python -m benchmark.ruler.runner \\
+        --model-url http://localhost:30000 \\
+        --context-lengths 4096,8192 \\
+        --tasks niah_single_1,vt \\
+        --output /tmp/ruler_results.jsonl \\
+        --mode both \\
+        --snapshot-dir /tmp/ruler_snapshots \\
+        --num-samples 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from .judge import ExactMatchScorer
+from .results import RestoreMode, RunSummary, TaskResult
+from .tasks import (
+    RULER_TASKS,
+    TaskInstance,
+    generate_synthetic_task,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Token counting
+# ---------------------------------------------------------------------------
+
+
+def _count_tokens(text: str) -> int:
+    """Count tokens using a tokenizer if available, else whitespace-split proxy."""
+    try:
+
+        # Use a fast generic tokenizer; cache it in a module-level variable
+        tok = _get_cached_tokenizer()
+        if tok is not None:
+            return len(tok.encode(text, add_special_tokens=False))
+    except Exception:
+        pass
+    # Fallback: whitespace split (≈1 token/word for English)
+    return len(text.split())
+
+
+_cached_tokenizer = None
+_tokenizer_tried = False
+
+
+def _get_cached_tokenizer():
+    global _cached_tokenizer, _tokenizer_tried
+    if _tokenizer_tried:
+        return _cached_tokenizer
+    _tokenizer_tried = True
+    try:
+        from transformers import AutoTokenizer  # type: ignore
+
+        _cached_tokenizer = AutoTokenizer.from_pretrained(
+            "gpt2", use_fast=True, local_files_only=False
+        )
+    except Exception:
+        _cached_tokenizer = None
+    return _cached_tokenizer
+
+
+# ---------------------------------------------------------------------------
+# HTTP client abstraction (swap for real client in integration tests)
+# ---------------------------------------------------------------------------
+
+HttpClient = Callable[[str, str, str], Tuple[str, float]]
+"""Type alias: (model_url, prompt, model_name) -> (response_text, latency_s)"""
+
+
+def _real_http_client(
+    model_url: str,
+    prompt: str,
+    model_name: str,
+    max_new_tokens: int = 256,
+    timeout: int = 120,
+) -> Tuple[str, float]:
+    """Call an OpenAI-compatible /v1/completions endpoint."""
+    import requests  # type: ignore
+
+    payload = {
+        "model": model_name,
+        "prompt": prompt,
+        "max_tokens": max_new_tokens,
+        "temperature": 0.0,
+    }
+    url = model_url.rstrip("/") + "/v1/completions"
+    t0 = time.perf_counter()
+    resp = requests.post(url, json=payload, timeout=timeout)
+    latency = time.perf_counter() - t0
+    resp.raise_for_status()
+    data = resp.json()
+    text = data["choices"][0]["text"]
+    return text, latency
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+class RULERRunner:
+    """Two-phase RULER evaluation runner.
+
+    Args:
+        model_url: Base URL of the serving endpoint (e.g. http://localhost:30000).
+        model_name: Model name passed in the API payload.
+        snapshot_dir: Directory for Engram snapshots.  Each task gets its own
+            subdirectory keyed by task_id.
+        http_client: Optional injectable HTTP client (for testing).
+        scorer: Optional injectable scorer (default: ExactMatchScorer).
+        max_new_tokens: Max tokens to generate per request.
+    """
+
+    def __init__(
+        self,
+        model_url: str = "http://localhost:30000",
+        model_name: str = "model",
+        snapshot_dir: Optional[str | Path] = None,
+        http_client: Optional[HttpClient] = None,
+        scorer=None,
+        max_new_tokens: int = 256,
+    ) -> None:
+        self.model_url = model_url.rstrip("/")
+        self.model_name = model_name
+        self.snapshot_dir = Path(snapshot_dir) if snapshot_dir else Path("/tmp/ruler_snapshots")
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        self._http_client = http_client or _real_http_client
+        self.scorer = scorer if scorer is not None else ExactMatchScorer()
+        self.max_new_tokens = max_new_tokens
+
+    # ------------------------------------------------------------------ #
+    # Baseline phase                                                       #
+    # ------------------------------------------------------------------ #
+
+    def run_baseline(self, tasks: List[TaskInstance]) -> List[TaskResult]:
+        """Run baseline evaluation: always sends full context + question.
+
+        Args:
+            tasks: List of TaskInstance objects to evaluate.
+
+        Returns:
+            List of TaskResult with restore_mode="cold" (baseline never warms).
+        """
+        results: List[TaskResult] = []
+        for task in tasks:
+            prompt = self._build_full_prompt(task)
+            input_tokens = _count_tokens(prompt)
+
+            logger.info(
+                "Baseline | %s | ctx=%d | tokens=%d",
+                task.task_name,
+                task.context_length,
+                input_tokens,
+            )
+
+            answer, latency = self._call(prompt)
+            output_tokens = _count_tokens(answer)
+            score = self._score(answer, task.answer)
+
+            result = TaskResult(
+                task_id=task.task_id or task.task_name,
+                task_name=task.task_name,
+                context_length=task.context_length,
+                restore_mode="cold",  # Baseline is always cold (no snapshots)
+                baseline_ttft_s=latency,
+                baseline_input_tokens=input_tokens,
+                baseline_output_tokens=output_tokens,
+                baseline_answer=answer,
+                baseline_score=score,
+                # Engram fields not applicable in baseline-only mode; use sentinels
+                engram_ttft_s=0.0,
+                engram_input_tokens=0,
+                engram_output_tokens=0,
+                engram_answer="",
+                engram_score=0.0,
+            )
+            results.append(result)
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Engram phase                                                         #
+    # ------------------------------------------------------------------ #
+
+    def run_engram(self, tasks: List[TaskInstance]) -> List[TaskResult]:
+        """Run Engram evaluation with warm/cold snapshot logic.
+
+        Warm path (snapshot present): send only the question.
+        Cold path (no snapshot): send full context + question, then save
+        a stub snapshot so the next call with the same task is warm.
+
+        Args:
+            tasks: List of TaskInstance objects to evaluate.
+
+        Returns:
+            List of TaskResult with restore_mode set to "warm" or "cold".
+        """
+        results: List[TaskResult] = []
+        for task in tasks:
+            restore_mode, prompt, input_tokens = self._engram_prompt(task)
+
+            logger.info(
+                "Engram | %s | ctx=%d | mode=%s | tokens=%d",
+                task.task_name,
+                task.context_length,
+                restore_mode,
+                input_tokens,
+            )
+
+            answer, latency = self._call(prompt)
+            output_tokens = _count_tokens(answer)
+            score = self._score(answer, task.answer)
+
+            # If cold, save snapshot so subsequent runs are warm
+            if restore_mode == "cold":
+                self._save_snapshot(task)
+
+            result = TaskResult(
+                task_id=task.task_id or task.task_name,
+                task_name=task.task_name,
+                context_length=task.context_length,
+                restore_mode=restore_mode,
+                # Baseline fields filled with sentinels (Engram-only run)
+                baseline_ttft_s=0.0,
+                baseline_input_tokens=_count_tokens(self._build_full_prompt(task)),
+                baseline_output_tokens=0,
+                baseline_answer="",
+                baseline_score=0.0,
+                engram_ttft_s=latency,
+                engram_input_tokens=input_tokens,
+                engram_output_tokens=output_tokens,
+                engram_answer=answer,
+                engram_score=score,
+            )
+            results.append(result)
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Combined phase (both baseline and Engram in one pass)                #
+    # ------------------------------------------------------------------ #
+
+    def run_both(self, tasks: List[TaskInstance]) -> List[TaskResult]:
+        """Run both baseline and Engram for each task, merging into one result.
+
+        First runs baseline (always cold), then Engram (warm/cold based on
+        snapshot state).  Merges baseline and Engram fields into a single
+        TaskResult per task.
+        """
+        results: List[TaskResult] = []
+
+        for task in tasks:
+            # --- Baseline ---
+            baseline_prompt = self._build_full_prompt(task)
+            baseline_input_tokens = _count_tokens(baseline_prompt)
+            baseline_answer, baseline_latency = self._call(baseline_prompt)
+            baseline_output_tokens = _count_tokens(baseline_answer)
+            baseline_score = self._score(baseline_answer, task.answer)
+
+            # --- Engram ---
+            restore_mode, engram_prompt, engram_input_tokens = self._engram_prompt(task)
+            engram_answer, engram_latency = self._call(engram_prompt)
+            engram_output_tokens = _count_tokens(engram_answer)
+            engram_score = self._score(engram_answer, task.answer)
+
+            if restore_mode == "cold":
+                self._save_snapshot(task)
+
+            logger.info(
+                "Both | %s | ctx=%d | mode=%s | baseline_tok=%d | engram_tok=%d",
+                task.task_name,
+                task.context_length,
+                restore_mode,
+                baseline_input_tokens,
+                engram_input_tokens,
+            )
+
+            result = TaskResult(
+                task_id=task.task_id or task.task_name,
+                task_name=task.task_name,
+                context_length=task.context_length,
+                restore_mode=restore_mode,
+                baseline_ttft_s=baseline_latency,
+                baseline_input_tokens=baseline_input_tokens,
+                baseline_output_tokens=baseline_output_tokens,
+                baseline_answer=baseline_answer,
+                baseline_score=baseline_score,
+                engram_ttft_s=engram_latency,
+                engram_input_tokens=engram_input_tokens,
+                engram_output_tokens=engram_output_tokens,
+                engram_answer=engram_answer,
+                engram_score=engram_score,
+            )
+            results.append(result)
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _snapshot_path(self, task: TaskInstance) -> Path:
+        task_id = task.task_id or task.task_name
+        return self.snapshot_dir / task_id / "snapshot.json"
+
+    def _is_warm(self, task: TaskInstance) -> bool:
+        return self._snapshot_path(task).exists()
+
+    def _save_snapshot(self, task: TaskInstance) -> None:
+        snapshot_path = self._snapshot_path(task)
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        stub = {
+            "task_id": task.task_id,
+            "task_name": task.task_name,
+            "context_length": task.context_length,
+            "saved_at": time.time(),
+            "_note": "Stub snapshot — replace with real Engram state blob for GPU runs.",
+        }
+        snapshot_path.write_text(json.dumps(stub, indent=2), encoding="utf-8")
+        logger.debug("Saved snapshot: %s", snapshot_path)
+
+    def _engram_prompt(
+        self, task: TaskInstance
+    ) -> Tuple[RestoreMode, str, int]:
+        """Return (restore_mode, prompt_text, input_token_count)."""
+        if self._is_warm(task):
+            # Warm: snapshot exists — send only the question
+            prompt = f"Question: {task.question}\nAnswer:"
+            return "warm", prompt, _count_tokens(prompt)
+        else:
+            # Cold: no snapshot — send full context + question
+            prompt = self._build_full_prompt(task)
+            return "cold", prompt, _count_tokens(prompt)
+
+    def _build_full_prompt(self, task: TaskInstance) -> str:
+        return (
+            f"{task.context_text}\n\nQuestion: {task.question}\nAnswer:"
+        )
+
+    def _call(self, prompt: str) -> Tuple[str, float]:
+        """Invoke the HTTP client, returning (answer_text, latency_s)."""
+        return self._http_client(self.model_url, prompt, self.model_name)
+
+    def _score(self, answer: str, reference) -> float:
+        return self.scorer.score(answer, reference)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m benchmark.ruler.runner",
+        description="Run RULER benchmark against an Engram-compatible endpoint.",
+    )
+    parser.add_argument(
+        "--model-url",
+        default="http://localhost:30000",
+        help="Base URL of the serving endpoint.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default="model",
+        help="Model name passed in the API payload.",
+    )
+    parser.add_argument(
+        "--context-lengths",
+        default="4096,8192",
+        help="Comma-separated list of context lengths to benchmark.",
+    )
+    parser.add_argument(
+        "--tasks",
+        default=",".join(RULER_TASKS),
+        help="Comma-separated list of RULER task names.",
+    )
+    parser.add_argument(
+        "--output",
+        default="ruler_results.jsonl",
+        help="Output JSONL path.",
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        default="/tmp/ruler_snapshots",
+        help="Directory for Engram snapshots.",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=5,
+        help="Number of samples per (task, context_length) combination.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["baseline", "engram", "both"],
+        default="both",
+        help="Evaluation mode.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=256,
+        help="Max tokens to generate per request.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+    )
+
+    context_lengths = [int(x) for x in args.context_lengths.split(",")]
+    task_names = [t.strip() for t in args.tasks.split(",") if t.strip()]
+
+    # Validate task names
+    unknown = [t for t in task_names if t not in RULER_TASKS]
+    if unknown:
+        logger.error("Unknown task names: %s", unknown)
+        return 1
+
+    # Generate task instances
+    logger.info(
+        "Generating %d task × %d context_length × %d samples instances…",
+        len(task_names),
+        len(context_lengths),
+        args.num_samples,
+    )
+    task_instances: List[TaskInstance] = []
+    for task_name in task_names:
+        for ctx_len in context_lengths:
+            for sample_idx in range(args.num_samples):
+                task_instances.append(
+                    generate_synthetic_task(task_name, ctx_len, sample_idx)
+                )
+    logger.info("Total instances: %d", len(task_instances))
+
+    runner = RULERRunner(
+        model_url=args.model_url,
+        model_name=args.model_name,
+        snapshot_dir=args.snapshot_dir,
+        max_new_tokens=args.max_new_tokens,
+    )
+
+    summary = RunSummary(model=args.model_name)
+
+    if args.mode == "baseline":
+        results = runner.run_baseline(task_instances)
+        summary.results = results
+    elif args.mode == "engram":
+        results = runner.run_engram(task_instances)
+        summary.results = results
+    else:  # both
+        results = runner.run_both(task_instances)
+        summary.results = results
+
+    summary.to_jsonl(args.output)
+    logger.info("Results written to %s", args.output)
+    logger.info(
+        "token_reduction=%.3f  ttft_speedup=%.3fx  compute_amortization=%.0f",
+        summary.token_reduction,
+        summary.ttft_speedup,
+        summary.compute_amortization,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/ruler/tasks.py
+++ b/benchmark/ruler/tasks.py
@@ -1,0 +1,496 @@
+"""
+RULER task definitions and synthetic data generation.
+
+RULER (Really Urgent Long-context Evaluation for Research) tests 13 task
+types across configurable context lengths.  The dataset is generated
+synthetically — there is no fixed download corpus.
+
+Reference: https://huggingface.co/datasets/hsiehjackson/RULER
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import string
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional, Union
+
+
+# ---------------------------------------------------------------------------
+# Task catalogue
+# ---------------------------------------------------------------------------
+
+RULER_TASKS: List[str] = [
+    # Needle-in-a-haystack (single needle)
+    "niah_single_1",
+    "niah_single_2",
+    "niah_single_3",
+    # Needle-in-a-haystack (multi-key)
+    "niah_multikey_1",
+    "niah_multikey_2",
+    "niah_multikey_3",
+    # Needle-in-a-haystack (multi-value)
+    "niah_multivalue",
+    # Needle-in-a-haystack (multi-query)
+    "niah_multiquery",
+    # Variable tracking
+    "vt",
+    # Common words extraction
+    "cwe",
+    # Frequent words extraction
+    "fwe",
+    # Question answering
+    "qa_1",
+    "qa_2",
+]
+
+CONTEXT_LENGTHS: List[int] = [4096, 8192, 16384, 32768, 65536, 131072]
+
+_NIAH_TASKS = {t for t in RULER_TASKS if t.startswith("niah_")}
+_VT_TASKS = {"vt"}
+_CWE_TASKS = {"cwe"}
+_FWE_TASKS = {"fwe"}
+_QA_TASKS = {"qa_1", "qa_2"}
+
+
+class TaskType(str, Enum):
+    NIAH_SINGLE = "niah_single"
+    NIAH_MULTIKEY = "niah_multikey"
+    NIAH_MULTIVALUE = "niah_multivalue"
+    NIAH_MULTIQUERY = "niah_multiquery"
+    VT = "vt"
+    CWE = "cwe"
+    FWE = "fwe"
+    QA = "qa"
+
+    @classmethod
+    def from_task_name(cls, name: str) -> "TaskType":
+        if name.startswith("niah_single"):
+            return cls.NIAH_SINGLE
+        if name.startswith("niah_multikey"):
+            return cls.NIAH_MULTIKEY
+        if name == "niah_multivalue":
+            return cls.NIAH_MULTIVALUE
+        if name == "niah_multiquery":
+            return cls.NIAH_MULTIQUERY
+        if name == "vt":
+            return cls.VT
+        if name == "cwe":
+            return cls.CWE
+        if name == "fwe":
+            return cls.FWE
+        if name.startswith("qa_"):
+            return cls.QA
+        raise ValueError(f"Unknown RULER task name: {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaskInstance:
+    """A single RULER task instance ready for evaluation."""
+
+    task_name: str
+    context_length: int  # nominal context length bucket (tokens, approximate)
+    context_text: str  # the long-context document / filler text
+    question: str  # the question to ask after (or about) the context
+    answer: Union[str, List[str]]  # ground-truth answer(s)
+
+    # Optional: stable ID derived from content for snapshot keying
+    task_id: Optional[str] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.task_id is None:
+            # Deterministic ID from task_name + context_length + answer (which
+            # is unique per sample because it encodes the hidden needle/value).
+            # This ensures different sample_idx values produce different task_ids
+            # even when the question text is identical across samples.
+            answer_str = (
+                "|".join(self.answer) if isinstance(self.answer, list) else self.answer
+            )
+            digest = hashlib.sha1(
+                f"{self.task_name}|{self.context_length}|{answer_str}".encode()
+            ).hexdigest()[:12]
+            self.task_id = f"{self.task_name}_cl{self.context_length}_{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic generation helpers
+# ---------------------------------------------------------------------------
+
+_LOREM = (
+    "The quick brown fox jumps over the lazy dog. "
+    "A stitch in time saves nine. "
+    "All that glitters is not gold. "
+    "To be or not to be that is the question. "
+    "It was the best of times it was the worst of times. "
+)
+
+_WORDS_POOL = [
+    "apple", "banana", "cherry", "diamond", "elephant",
+    "falcon", "granite", "horizon", "island", "jungle",
+    "kettle", "lantern", "mosaic", "nebula", "orchid",
+    "palace", "quartz", "radiant", "sapphire", "twilight",
+    "umbrella", "velvet", "walnut", "xenon", "yellow", "zephyr",
+]
+
+
+def _filler_text(approx_tokens: int) -> str:
+    """Generate filler text of approximately `approx_tokens` tokens.
+
+    Uses whitespace-split proxy: 1 word ≈ 1 token (conservative).
+    """
+    # Repeat lorem until we have enough words
+    words_needed = approx_tokens
+    source = _LOREM.split()
+    repetitions = (words_needed // len(source)) + 2
+    words = (source * repetitions)[:words_needed]
+    return " ".join(words)
+
+
+def _random_needle(seed: int) -> str:
+    """Return a deterministic 'needle' string for NIAH tasks."""
+    rng = random.Random(seed)
+    adj = rng.choice(["secret", "hidden", "magic", "special", "unique"])
+    noun = rng.choice(["code", "phrase", "word", "key", "token"])
+    value = "".join(rng.choices(string.ascii_uppercase + string.digits, k=8))
+    return f"The {adj} {noun} is: {value}"
+
+
+def _extract_needle_value(needle: str) -> str:
+    """Extract the value portion from a needle string."""
+    return needle.split(": ", 1)[-1].strip()
+
+
+# ---------------------------------------------------------------------------
+# Task generators — all offline, no network required
+# ---------------------------------------------------------------------------
+
+
+def _generate_niah_single(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Single needle in a haystack."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    needle = _random_needle(seed)
+    value = _extract_needle_value(needle)
+
+    # Determine needle depth (where in the context to insert)
+    # niah_single_1 = 50%, _2 = 10%, _3 = 90%
+    depth_map = {"niah_single_1": 0.5, "niah_single_2": 0.1, "niah_single_3": 0.9}
+    depth = depth_map.get(task_name, 0.5)
+
+    filler_tokens = max(0, context_length - 30)
+    filler = _filler_text(filler_tokens)
+    words = filler.split()
+    insert_pos = int(len(words) * depth)
+    words.insert(insert_pos, needle)
+    context_text = " ".join(words)
+
+    question = "What is the secret code hidden in the text? Provide only the exact value."
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=value,
+    )
+
+
+def _generate_niah_multikey(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Multiple distinct needles; ask for one specific key."""
+    num_keys_map = {"niah_multikey_1": 2, "niah_multikey_2": 4, "niah_multikey_3": 8}
+    num_keys = num_keys_map.get(task_name, 2)
+
+    seed_base = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    needles = [_random_needle(seed_base + i) for i in range(num_keys)]
+    values = [_extract_needle_value(n) for n in needles]
+
+    filler_tokens = max(0, context_length - 40 * num_keys)
+    filler = _filler_text(filler_tokens)
+    words = filler.split()
+
+    # Distribute needles evenly
+    for i, needle in enumerate(needles):
+        pos = int(len(words) * ((i + 1) / (num_keys + 1)))
+        words.insert(pos + i, needle)
+
+    context_text = " ".join(words)
+
+    # Ask for the first needle's value (deterministic)
+    target_value = values[0]
+    target_needle_phrase = needles[0].split(": ")[0].replace("The ", "")
+    question = (
+        f"What is the value associated with the '{target_needle_phrase}'? "
+        "Provide only the exact value."
+    )
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=target_value,
+    )
+
+
+def _generate_niah_multivalue(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """One key, multiple values; ask for all values."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+    num_values = 3
+    values = [
+        "".join(rng.choices(string.ascii_uppercase + string.digits, k=6))
+        for _ in range(num_values)
+    ]
+    needles = [f"The magic token number {i + 1} is: {v}" for i, v in enumerate(values)]
+
+    filler_tokens = max(0, context_length - 40 * num_values)
+    filler = _filler_text(filler_tokens)
+    words = filler.split()
+
+    for i, needle in enumerate(needles):
+        pos = int(len(words) * ((i + 1) / (num_values + 1)))
+        words.insert(pos + i, needle)
+
+    context_text = " ".join(words)
+    question = "List all magic token values mentioned in the text, in order."
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=values,  # list — any one match scores
+    )
+
+
+def _generate_niah_multiquery(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """One needle, multiple question phrasings."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    needle = _random_needle(seed)
+    value = _extract_needle_value(needle)
+
+    filler_tokens = max(0, context_length - 30)
+    filler = _filler_text(filler_tokens)
+    words = filler.split()
+    words.insert(len(words) // 2, needle)
+    context_text = " ".join(words)
+
+    question = (
+        "What special value or code is hidden in the text? "
+        "What secret phrase appears in the document? "
+        "Provide only the value you find."
+    )
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=value,
+    )
+
+
+def _generate_vt(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Variable tracking — trace a chain of variable assignments."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+
+    # Build a chain: X0 = val, X1 = X0, X2 = X1, ..., Xn = X(n-1)
+    chain_length = max(3, context_length // 2000)
+    initial_value = "".join(rng.choices(string.digits, k=4))
+
+    assignments = [f"Let X0 = {initial_value}."]
+    for i in range(1, chain_length):
+        assignments.append(f"Let X{i} = X{i - 1}.")
+
+    assignment_text = " ".join(assignments)
+    filler_tokens = max(10, context_length - len(assignment_text.split()) - 20)
+    filler = _filler_text(filler_tokens)
+
+    # Interleave: filler, then assignments at depth 50%
+    words = filler.split()
+    insert_pos = len(words) // 2
+    words.insert(insert_pos, assignment_text)
+    context_text = " ".join(words)
+
+    final_var = f"X{chain_length - 1}"
+    question = f"What is the value of {final_var}?"
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=initial_value,
+    )
+
+
+def _generate_cwe(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Common words extraction — find words that appear most frequently."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+
+    # Pick 3 "common" words that will be sprinkled throughout
+    common_words = rng.sample(_WORDS_POOL[:15], 3)
+
+    # Build a word list with controlled frequencies
+    num_words = max(50, context_length // 4)
+    background = rng.choices(_WORDS_POOL[15:], k=num_words)
+
+    # Insert common words many times
+    inserts = common_words * (num_words // 10)
+    all_words = background + inserts
+    rng.shuffle(all_words)
+
+    context_text = " ".join(all_words)
+    question = (
+        "What are the three most common words in the text? "
+        "List them separated by commas."
+    )
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=common_words,
+    )
+
+
+def _generate_fwe(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Frequent words extraction — similar to CWE but different framing."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+
+    frequent_words = rng.sample(_WORDS_POOL[:10], 2)
+    num_words = max(50, context_length // 4)
+    background = rng.choices(_WORDS_POOL[10:], k=num_words)
+    inserts = frequent_words * (num_words // 8)
+    all_words = background + inserts
+    rng.shuffle(all_words)
+
+    context_text = " ".join(all_words)
+    question = (
+        "Which words appear most frequently in the passage? "
+        "List the top 2 most frequent words."
+    )
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=frequent_words,
+    )
+
+
+def _generate_qa(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Minimal synthetic QA task."""
+    seed = hash((task_name, context_length, sample_idx)) & 0xFFFFFFFF
+    rng = random.Random(seed)
+
+    # Embed a simple fact
+    entity = rng.choice(["Alice", "Bob", "Carol", "Dave", "Eve"])
+    location = rng.choice(["Paris", "Tokyo", "London", "Sydney", "Cairo"])
+    year = rng.randint(1900, 2020)
+
+    fact = f"{entity} was born in {location} in the year {year}."
+    filler_tokens = max(10, context_length - 30)
+    filler = _filler_text(filler_tokens)
+    words = filler.split()
+
+    insert_pos = rng.randint(0, max(0, len(words) - 1))
+    words.insert(insert_pos, fact)
+    context_text = " ".join(words)
+
+    if task_name == "qa_1":
+        question = f"Where was {entity} born?"
+        answer = location
+    else:  # qa_2
+        question = f"In what year was {entity} born?"
+        answer = str(year)
+
+    return TaskInstance(
+        task_name=task_name,
+        context_length=context_length,
+        context_text=context_text,
+        question=question,
+        answer=answer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_GENERATORS = {
+    "niah_single_1": _generate_niah_single,
+    "niah_single_2": _generate_niah_single,
+    "niah_single_3": _generate_niah_single,
+    "niah_multikey_1": _generate_niah_multikey,
+    "niah_multikey_2": _generate_niah_multikey,
+    "niah_multikey_3": _generate_niah_multikey,
+    "niah_multivalue": _generate_niah_multivalue,
+    "niah_multiquery": _generate_niah_multiquery,
+    "vt": _generate_vt,
+    "cwe": _generate_cwe,
+    "fwe": _generate_fwe,
+    "qa_1": _generate_qa,
+    "qa_2": _generate_qa,
+}
+
+
+def generate_synthetic_task(
+    task_name: str,
+    context_length: int,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    """Generate a synthetic RULER task instance without any external downloads.
+
+    Args:
+        task_name: One of the 13 RULER task names in RULER_TASKS.
+        context_length: Nominal context length in tokens (approximate).
+        sample_idx: Sample index for deterministic variation within a task.
+
+    Returns:
+        A fully-populated TaskInstance ready for evaluation.
+
+    Raises:
+        ValueError: If task_name is not in RULER_TASKS.
+    """
+    if task_name not in _GENERATORS:
+        raise ValueError(
+            f"Unknown task: {task_name!r}. Must be one of: {RULER_TASKS}"
+        )
+    return _GENERATORS[task_name](task_name, context_length, sample_idx)

--- a/benchmark/ruler/test_dry_run.py
+++ b/benchmark/ruler/test_dry_run.py
@@ -14,7 +14,7 @@ from typing import Tuple
 
 import pytest
 
-from .judge import ExactMatchScorer, MockJudge
+from .judge import MockJudge, StringMatchAllScorer, StringMatchPartScorer, get_scorer
 from .results import RunSummary, TaskResult
 from .runner import RULERRunner, _count_tokens
 from .tasks import (
@@ -274,21 +274,87 @@ class TestSyntheticGeneration:
         with pytest.raises(ValueError, match="Unknown task"):
             generate_synthetic_task("not_a_real_task", 4096)
 
-    def test_exact_match_scorer(self):
-        """ExactMatchScorer returns 1.0 for correct containment, 0.0 otherwise."""
-        scorer = ExactMatchScorer()
+    def test_string_match_all_scorer_single_reference(self):
+        """StringMatchAllScorer: single ref found → 1.0, not found → 0.0."""
+        scorer = StringMatchAllScorer()
 
-        # String reference
         assert scorer.score("The answer is ABCD1234", "ABCD1234") == 1.0
         assert scorer.score("ABCD1234", "ABCD1234") == 1.0
         assert scorer.score("wrong answer", "ABCD1234") == 0.0
 
-        # List reference — any match passes
+    def test_string_match_all_scorer_case_insensitive(self):
+        """StringMatchAllScorer is case-insensitive."""
+        scorer = StringMatchAllScorer()
+        assert scorer.score("paris is the capital", "Paris") == 1.0
+        assert scorer.score("PARIS", "paris") == 1.0
+
+    def test_string_match_all_scorer_recall_based(self):
+        """StringMatchAllScorer returns the fraction of refs found (recall)."""
+        scorer = StringMatchAllScorer()
+
+        # All 3 refs present → 1.0
+        assert scorer.score("apple banana cherry", ["apple", "banana", "cherry"]) == 1.0
+        # 2 of 3 refs present → 2/3
+        assert abs(scorer.score("apple banana", ["apple", "banana", "cherry"]) - 2 / 3) < 1e-9
+        # 0 of 3 refs present → 0.0
+        assert scorer.score("mango grape", ["apple", "banana", "cherry"]) == 0.0
+
+    def test_string_match_all_scorer_returns_fraction_not_percent(self):
+        """StringMatchAllScorer returns [0.0, 1.0], not [0, 100]."""
+        scorer = StringMatchAllScorer()
+        result = scorer.score("apple banana", ["apple", "banana"])
+        assert 0.0 <= result <= 1.0
+
+    def test_string_match_part_scorer_any_match(self):
+        """StringMatchPartScorer: 1.0 if any ref found, 0.0 if none."""
+        scorer = StringMatchPartScorer()
+
+        # Any one match is sufficient
         assert scorer.score("Paris", ["London", "Paris", "Tokyo"]) == 1.0
+        assert scorer.score("London is great", ["London", "Paris", "Tokyo"]) == 1.0
+        # No match → 0.0
         assert scorer.score("Sydney", ["London", "Paris", "Tokyo"]) == 0.0
 
-        # Case insensitivity
-        assert scorer.score("paris", "Paris") == 1.0
+    def test_string_match_part_scorer_case_insensitive(self):
+        """StringMatchPartScorer is case-insensitive."""
+        scorer = StringMatchPartScorer()
+        assert scorer.score("the answer is paris", "Paris") == 1.0
+        assert scorer.score("PARIS", "paris") == 1.0
+
+    def test_string_match_part_scorer_single_reference(self):
+        """StringMatchPartScorer works with a single string reference."""
+        scorer = StringMatchPartScorer()
+        assert scorer.score("The capital is Berlin", "Berlin") == 1.0
+        assert scorer.score("The capital is Rome", "Berlin") == 0.0
+
+    def test_string_match_part_scorer_returns_fraction_not_percent(self):
+        """StringMatchPartScorer returns [0.0, 1.0], not [0, 100]."""
+        scorer = StringMatchPartScorer()
+        result = scorer.score("apple", ["apple", "banana"])
+        assert 0.0 <= result <= 1.0
+
+    def test_get_scorer_qa_tasks_use_part(self):
+        """get_scorer returns StringMatchPartScorer for qa_1 and qa_2."""
+        assert isinstance(get_scorer("qa_1"), StringMatchPartScorer)
+        assert isinstance(get_scorer("qa_2"), StringMatchPartScorer)
+
+    def test_get_scorer_non_qa_tasks_use_all(self):
+        """get_scorer returns StringMatchAllScorer for all non-QA RULER tasks."""
+        non_qa_tasks = [
+            "niah_single_1", "niah_single_2", "niah_single_3",
+            "niah_multikey_1", "niah_multikey_2", "niah_multikey_3",
+            "niah_multivalue", "niah_multiquery",
+            "vt", "cwe", "fwe",
+        ]
+        for task_name in non_qa_tasks:
+            scorer = get_scorer(task_name)
+            assert isinstance(scorer, StringMatchAllScorer), (
+                f"Expected StringMatchAllScorer for {task_name}, got {type(scorer).__name__}"
+            )
+
+    def test_get_scorer_unknown_task_defaults_to_all(self):
+        """get_scorer falls back to StringMatchAllScorer for unknown task names."""
+        assert isinstance(get_scorer("unknown_task"), StringMatchAllScorer)
 
     def test_mock_judge(self):
         """MockJudge returns 1.0 for non-empty, 0.0 for empty."""
@@ -476,7 +542,7 @@ class TestRunnerDryRun:
         answer = task.answer if isinstance(task.answer, str) else task.answer[0]
         client = _make_mock_http_client(answer=answer)
 
-        scorer = ExactMatchScorer()
+        scorer = StringMatchAllScorer()
         runner = RULERRunner(
             model_url="http://mock:30000",
             model_name="mock",

--- a/benchmark/ruler/test_dry_run.py
+++ b/benchmark/ruler/test_dry_run.py
@@ -1,0 +1,530 @@
+"""
+CPU/mock dry-run tests for the RULER benchmark harness.
+
+All tests run without a GPU, without an active model server, and without
+any network access.  External HTTP calls are replaced by a mock client.
+
+Run with:
+    pytest benchmark/ruler/test_dry_run.py -v
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import pytest
+
+from .judge import ExactMatchScorer, MockJudge
+from .results import RunSummary, TaskResult
+from .runner import RULERRunner, _count_tokens
+from .tasks import (
+    RULER_TASKS,
+    TaskInstance,
+    generate_synthetic_task,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_http_client(answer: str = "ABCD1234", latency: float = 0.05):
+    """Return a mock HTTP client that always responds with `answer`."""
+
+    def client(model_url: str, prompt: str, model_name: str) -> Tuple[str, float]:
+        return answer, latency
+
+    return client
+
+
+@pytest.fixture
+def mock_http_client():
+    return _make_mock_http_client()
+
+
+@pytest.fixture
+def tmp_snapshot_dir(tmp_path):
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    return snapshot_dir
+
+
+def _make_task(
+    task_name: str = "niah_single_1",
+    context_length: int = 4096,
+    sample_idx: int = 0,
+) -> TaskInstance:
+    return generate_synthetic_task(task_name, context_length, sample_idx)
+
+
+def _make_full_task_result(
+    restore_mode="cold",
+    task_name="niah_single_1",
+    context_length=4096,
+) -> TaskResult:
+    return TaskResult(
+        task_id=f"{task_name}_cl{context_length}_test",
+        task_name=task_name,
+        context_length=context_length,
+        restore_mode=restore_mode,
+        baseline_ttft_s=1.0,
+        baseline_input_tokens=1000,
+        baseline_output_tokens=10,
+        baseline_answer="ABCD1234",
+        baseline_score=1.0,
+        engram_ttft_s=0.2,
+        engram_input_tokens=20,
+        engram_output_tokens=10,
+        engram_answer="ABCD1234",
+        engram_score=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestResultsSchema
+# ---------------------------------------------------------------------------
+
+
+class TestResultsSchema:
+    def test_task_result_warm_cold_label(self):
+        """TaskResult must carry a warm/cold restore_mode."""
+        warm_result = _make_full_task_result(restore_mode="warm")
+        cold_result = _make_full_task_result(restore_mode="cold")
+
+        assert warm_result.restore_mode == "warm"
+        assert cold_result.restore_mode == "cold"
+
+    def test_run_summary_aggregates_by_task(self):
+        """RunSummary.by_task() groups results correctly."""
+        results = [
+            _make_full_task_result(task_name="niah_single_1"),
+            _make_full_task_result(task_name="niah_single_1"),
+            _make_full_task_result(task_name="vt"),
+        ]
+        summary = RunSummary(model="test-model", results=results)
+        by_task = summary.by_task()
+
+        assert set(by_task.keys()) == {"niah_single_1", "vt"}
+        assert len(by_task["niah_single_1"]) == 2
+        assert len(by_task["vt"]) == 1
+
+    def test_jsonl_roundtrip(self, tmp_path):
+        """to_jsonl / from_jsonl preserves all fields."""
+        results = [
+            _make_full_task_result(restore_mode="warm"),
+            _make_full_task_result(restore_mode="cold", task_name="vt"),
+        ]
+        summary = RunSummary(model="roundtrip-model", results=results)
+        path = tmp_path / "test.jsonl"
+        summary.to_jsonl(path)
+
+        loaded = RunSummary.from_jsonl(path)
+        assert loaded.model == "roundtrip-model"
+        assert len(loaded.results) == 2
+        modes = {r.restore_mode for r in loaded.results}
+        assert modes == {"warm", "cold"}
+        task_names = {r.task_name for r in loaded.results}
+        assert task_names == {"niah_single_1", "vt"}
+
+    def test_metrics(self):
+        """Token reduction, TTFT speedup, and compute amortization are correct."""
+        # 1000 baseline tokens, 20 engram tokens → 98% reduction
+        result = _make_full_task_result()
+        summary = RunSummary(results=[result])
+
+        assert abs(summary.token_reduction - (1 - 20 / 1000)) < 1e-6
+        # Speedup = 1.0 / 0.2 = 5.0
+        assert abs(summary.ttft_speedup - 5.0) < 1e-6
+        # Amortization = 1000 - 20 = 980
+        assert summary.compute_amortization == 980.0
+
+    def test_warm_cold_breakdown(self):
+        """Warm and cold breakdowns are computed independently."""
+        warm = _make_full_task_result(restore_mode="warm")
+        cold = TaskResult(
+            task_id="cold_task",
+            task_name="vt",
+            context_length=4096,
+            restore_mode="cold",
+            baseline_ttft_s=1.0,
+            baseline_input_tokens=500,
+            baseline_output_tokens=10,
+            baseline_answer="",
+            baseline_score=0.0,
+            engram_ttft_s=0.8,
+            engram_input_tokens=500,  # cold path: same tokens
+            engram_output_tokens=10,
+            engram_answer="",
+            engram_score=0.0,
+        )
+        summary = RunSummary(results=[warm, cold])
+
+        # Warm: 20/1000 input → 98% reduction
+        assert abs(summary.warm_token_reduction() - (1 - 20 / 1000)) < 1e-6
+        # Cold: same tokens → 0% reduction
+        assert abs(summary.cold_token_reduction()) < 1e-6
+
+    def test_empty_summary_metrics(self):
+        """Empty RunSummary returns safe defaults."""
+        summary = RunSummary()
+        assert summary.token_reduction == 0.0
+        assert summary.compute_amortization == 0.0
+
+    def test_task_result_serialization(self):
+        """TaskResult.to_dict() / from_dict() is lossless."""
+        original = _make_full_task_result(restore_mode="warm")
+        roundtripped = TaskResult.from_dict(original.to_dict())
+        assert roundtripped.restore_mode == "warm"
+        assert roundtripped.baseline_input_tokens == 1000
+        assert roundtripped.engram_input_tokens == 20
+        assert roundtripped.baseline_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# TestSyntheticGeneration
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticGeneration:
+    def test_generate_niah_task(self):
+        """NIAH synthetic tasks contain the needle in the context."""
+        instance = generate_synthetic_task("niah_single_1", 4096)
+
+        assert instance.task_name == "niah_single_1"
+        assert instance.context_length == 4096
+        assert isinstance(instance.answer, str)
+        assert len(instance.answer) > 0
+        # Needle value should appear in context
+        assert instance.answer in instance.context_text
+
+    def test_generate_vt_task(self):
+        """Variable tracking task embeds the answer in the context."""
+        instance = generate_synthetic_task("vt", 4096)
+
+        assert instance.task_name == "vt"
+        assert isinstance(instance.answer, str)
+        assert len(instance.answer) > 0
+        # The initial variable value should be present somewhere in context
+        assert instance.answer in instance.context_text
+
+    def test_generate_cwe_task(self):
+        """CWE task returns a list of common words as the answer."""
+        instance = generate_synthetic_task("cwe", 4096)
+
+        assert instance.task_name == "cwe"
+        assert isinstance(instance.answer, list)
+        assert len(instance.answer) >= 1
+
+    def test_generate_fwe_task(self):
+        """FWE task returns a list of frequent words."""
+        instance = generate_synthetic_task("fwe", 4096)
+
+        assert isinstance(instance.answer, list)
+        assert len(instance.answer) >= 1
+
+    def test_generate_qa_tasks(self):
+        """QA tasks embed a fact and return a string answer."""
+        for task_name in ["qa_1", "qa_2"]:
+            instance = generate_synthetic_task(task_name, 4096)
+            assert isinstance(instance.answer, str)
+            assert len(instance.answer) > 0
+            assert instance.answer in instance.context_text
+
+    def test_generate_multikey_tasks(self):
+        """Multi-key NIAH tasks produce string answers."""
+        for task_name in ["niah_multikey_1", "niah_multikey_2", "niah_multikey_3"]:
+            instance = generate_synthetic_task(task_name, 4096)
+            assert isinstance(instance.answer, str)
+            assert len(instance.answer) > 0
+
+    def test_generate_multivalue_task(self):
+        """Multi-value NIAH task produces a list answer."""
+        instance = generate_synthetic_task("niah_multivalue", 4096)
+        assert isinstance(instance.answer, list)
+        assert len(instance.answer) >= 2
+
+    def test_generate_multiquery_task(self):
+        """Multi-query NIAH task produces a string answer."""
+        instance = generate_synthetic_task("niah_multiquery", 4096)
+        assert isinstance(instance.answer, str)
+
+    def test_task_id_is_deterministic(self):
+        """Same inputs produce the same task_id."""
+        inst1 = generate_synthetic_task("niah_single_1", 4096, 0)
+        inst2 = generate_synthetic_task("niah_single_1", 4096, 0)
+        assert inst1.task_id == inst2.task_id
+
+    def test_task_id_differs_by_sample_idx(self):
+        """Different sample_idx values produce different task_ids."""
+        inst0 = generate_synthetic_task("niah_single_1", 4096, 0)
+        inst1 = generate_synthetic_task("niah_single_1", 4096, 1)
+        assert inst0.task_id != inst1.task_id
+
+    def test_all_13_tasks_generate_without_error(self):
+        """All 13 RULER task types generate successfully."""
+        for task_name in RULER_TASKS:
+            instance = generate_synthetic_task(task_name, 4096)
+            assert instance.task_name == task_name
+            assert len(instance.context_text) > 0
+            assert len(instance.question) > 0
+
+    def test_unknown_task_raises(self):
+        """Requesting an unknown task name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown task"):
+            generate_synthetic_task("not_a_real_task", 4096)
+
+    def test_exact_match_scorer(self):
+        """ExactMatchScorer returns 1.0 for correct containment, 0.0 otherwise."""
+        scorer = ExactMatchScorer()
+
+        # String reference
+        assert scorer.score("The answer is ABCD1234", "ABCD1234") == 1.0
+        assert scorer.score("ABCD1234", "ABCD1234") == 1.0
+        assert scorer.score("wrong answer", "ABCD1234") == 0.0
+
+        # List reference — any match passes
+        assert scorer.score("Paris", ["London", "Paris", "Tokyo"]) == 1.0
+        assert scorer.score("Sydney", ["London", "Paris", "Tokyo"]) == 0.0
+
+        # Case insensitivity
+        assert scorer.score("paris", "Paris") == 1.0
+
+    def test_mock_judge(self):
+        """MockJudge returns 1.0 for non-empty, 0.0 for empty."""
+        judge = MockJudge()
+        assert judge.score("some answer", "reference") == 1.0
+        assert judge.score("", "reference") == 0.0
+        assert judge.score("   ", "reference") == 0.0
+
+    def test_context_text_scales_with_length(self):
+        """Larger context_length produces longer context text."""
+        small = generate_synthetic_task("niah_single_1", 512)
+        large = generate_synthetic_task("niah_single_1", 4096)
+        assert len(large.context_text) > len(small.context_text)
+
+
+# ---------------------------------------------------------------------------
+# TestRunnerDryRun
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerDryRun:
+    def _make_runner(self, mock_http_client, tmp_snapshot_dir):
+        return RULERRunner(
+            model_url="http://mock-server:30000",
+            model_name="mock-model",
+            snapshot_dir=tmp_snapshot_dir,
+            http_client=mock_http_client,
+            scorer=MockJudge(),
+        )
+
+    def test_baseline_run(self, mock_http_client, tmp_snapshot_dir):
+        """Baseline run produces TaskResult objects with restore_mode='cold'."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        tasks = [_make_task("niah_single_1", 4096)]
+
+        results = runner.run_baseline(tasks)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.restore_mode == "cold"
+        assert r.baseline_ttft_s > 0
+        assert r.baseline_input_tokens > 0
+        assert r.baseline_answer != "" or r.baseline_answer == ""  # any string is ok
+
+    def test_engram_cold_run(self, mock_http_client, tmp_snapshot_dir):
+        """Engram run without a snapshot produces restore_mode='cold'."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        # Ensure no snapshot exists
+        snapshot_path = runner._snapshot_path(task)
+        assert not snapshot_path.exists()
+
+        results = runner.run_engram([task])
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.restore_mode == "cold"
+        # After a cold run, snapshot should be created
+        assert snapshot_path.exists()
+
+    def test_engram_warm_run(self, mock_http_client, tmp_snapshot_dir):
+        """Engram run with a pre-existing snapshot produces restore_mode='warm'."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        # Pre-create the snapshot
+        runner._save_snapshot(task)
+        assert runner._snapshot_path(task).exists()
+
+        results = runner.run_engram([task])
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.restore_mode == "warm"
+
+    def test_warm_cold_labeling(self, mock_http_client, tmp_snapshot_dir):
+        """First engram call is cold; second (same task) is warm."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        # First call — cold
+        results_cold = runner.run_engram([task])
+        assert results_cold[0].restore_mode == "cold"
+
+        # Second call — warm (snapshot was saved by first call)
+        results_warm = runner.run_engram([task])
+        assert results_warm[0].restore_mode == "warm"
+
+    def test_warm_tokens_less_than_cold(self, mock_http_client, tmp_snapshot_dir):
+        """Warm path sends fewer tokens than cold path for the same task."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        # Cold run — gets full prompt
+        cold_results = runner.run_engram([task])
+        cold_tokens = cold_results[0].engram_input_tokens
+
+        # Warm run — gets question-only prompt
+        warm_results = runner.run_engram([task])
+        warm_tokens = warm_results[0].engram_input_tokens
+
+        assert warm_tokens < cold_tokens, (
+            f"Warm should use fewer tokens than cold: warm={warm_tokens}, cold={cold_tokens}"
+        )
+
+    def test_run_both_produces_all_fields(self, mock_http_client, tmp_snapshot_dir):
+        """run_both fills both baseline_* and engram_* fields in each result."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        results = runner.run_both([task])
+
+        assert len(results) == 1
+        r = results[0]
+        # Both sides should have non-trivial values
+        assert r.baseline_input_tokens > 0
+        assert r.engram_input_tokens > 0
+        assert r.restore_mode in ("warm", "cold")
+
+    def test_multiple_tasks(self, mock_http_client, tmp_snapshot_dir):
+        """Runner handles multiple task instances correctly."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        tasks = [
+            _make_task("niah_single_1", 4096),
+            _make_task("vt", 4096),
+            _make_task("qa_1", 4096),
+        ]
+
+        results = runner.run_both(tasks)
+        assert len(results) == 3
+        task_names = {r.task_name for r in results}
+        assert task_names == {"niah_single_1", "vt", "qa_1"}
+
+    def test_run_summary_integration(self, mock_http_client, tmp_snapshot_dir, tmp_path):
+        """Full pipeline: run_both → RunSummary → to_jsonl → from_jsonl."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        tasks = [_make_task("niah_single_1", 4096)]
+
+        results = runner.run_both(tasks)
+        summary = RunSummary(model="integration-test", results=results)
+
+        output_path = tmp_path / "ruler_test.jsonl"
+        summary.to_jsonl(output_path)
+
+        loaded = RunSummary.from_jsonl(output_path)
+        assert len(loaded.results) == 1
+        assert loaded.results[0].restore_mode in ("warm", "cold")
+        assert loaded.model == "integration-test"
+
+    def test_snapshot_dir_created_automatically(self, mock_http_client, tmp_path):
+        """Runner creates snapshot_dir if it does not exist."""
+        snap_dir = tmp_path / "does" / "not" / "exist"
+        assert not snap_dir.exists()
+
+        RULERRunner(
+            model_url="http://mock:30000",
+            model_name="mock",
+            snapshot_dir=snap_dir,
+            http_client=mock_http_client,
+            scorer=MockJudge(),
+        )
+        assert snap_dir.exists()
+
+    def test_token_counting_proxy(self):
+        """_count_tokens returns a positive integer for non-empty text."""
+        assert _count_tokens("hello world foo") == 3
+        assert _count_tokens("") == 0
+
+    def test_baseline_does_not_create_snapshots(self, mock_http_client, tmp_snapshot_dir):
+        """Baseline run must NOT create any snapshots."""
+        runner = self._make_runner(mock_http_client, tmp_snapshot_dir)
+        task = _make_task("niah_single_1", 4096)
+
+        runner.run_baseline([task])
+
+        # Snapshot directory should be empty (no snapshot created)
+        snapshot_path = runner._snapshot_path(task)
+        assert not snapshot_path.exists()
+
+    def test_engram_cold_then_warm_score_equal(self, tmp_snapshot_dir):
+        """Score should be consistent between cold and warm runs given same mock answer."""
+        # Use an answer that matches the task's answer for scoring
+        task = _make_task("niah_single_1", 4096)
+        answer = task.answer if isinstance(task.answer, str) else task.answer[0]
+        client = _make_mock_http_client(answer=answer)
+
+        scorer = ExactMatchScorer()
+        runner = RULERRunner(
+            model_url="http://mock:30000",
+            model_name="mock",
+            snapshot_dir=tmp_snapshot_dir,
+            http_client=client,
+            scorer=scorer,
+        )
+
+        cold_results = runner.run_engram([task])
+        warm_results = runner.run_engram([task])
+
+        assert cold_results[0].engram_score == 1.0
+        assert warm_results[0].engram_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# TestDownloadModule
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadModule:
+    def test_generate_dataset_small(self, tmp_path):
+        """generate_dataset() works offline with a small config."""
+        from .download import generate_dataset, load_dataset
+
+        output = tmp_path / "test_dataset.jsonl"
+        instances = generate_dataset(
+            tasks=["niah_single_1", "vt"],
+            context_lengths=[4096],
+            num_samples=2,
+            output_path=output,
+        )
+
+        assert len(instances) == 4  # 2 tasks × 1 ctx_len × 2 samples
+        assert output.exists()
+
+        # Reload and verify
+        loaded = load_dataset(output)
+        assert len(loaded) == 4
+        task_names = {inst.task_name for inst in loaded}
+        assert task_names == {"niah_single_1", "vt"}
+
+    def test_dataset_info_has_required_keys(self):
+        """RULER_DATASET_INFO contains all required metadata keys."""
+        from .download import RULER_DATASET_INFO
+
+        for key in ("name", "license", "tasks", "context_lengths", "num_tasks"):
+            assert key in RULER_DATASET_INFO
+
+        assert RULER_DATASET_INFO["license"] == "MIT"
+        assert len(RULER_DATASET_INFO["tasks"]) == 13


### PR DESCRIPTION
## Summary

Replaces the incorrect LLM-based judge in the RULER benchmark harness with the correct, verified programmatic scorers.

## Scoring method

**Official method (verified against hsiehjackson/RULER `constants.py`):**
Purely programmatic — no LLM judge.

- NIAH variants, VT, CWE, FWE: `string_match_all` — recall-based, fraction of reference strings found as substrings in prediction
- QA_1 (SQuAD), QA_2 (HotPotQA): `string_match_part` — 1.0 if any valid answer is a substring of the prediction

No `OPENAI_API_KEY` required for RULER scoring.

## Changes

- `judge.py`: Removed `GPT4oJudge` and `ExactMatchScorer`. Added `StringMatchAllScorer`, `StringMatchPartScorer`, and a `get_scorer(task_name)` factory. Kept `MockJudge` for dry-run compat.
- `runner.py`: Uses `get_scorer(task_name)` per-task when no scorer override is injected.
- `test_dry_run.py`: Removed old scorer tests; added coverage for both new scorers, the factory, and edge cases. 46 tests pass.

## Test plan

- [x] `python -m pytest benchmark/ruler/test_dry_run.py -v` — 46 passed, 0 failed
- [x] `StringMatchAllScorer` verified: recall fraction, case-insensitive, returns [0.0, 1.0]
- [x] `StringMatchPartScorer` verified: any-match, case-insensitive, returns [0.0, 1.0]
- [x] `get_scorer` factory: qa_1/qa_2 → Part, all others → All
- [x] No network access required; no OpenAI key needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26322477885](https://github.com/Clarit-AI/Engram/actions/runs/26322477885)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26322477741](https://github.com/Clarit-AI/Engram/actions/runs/26322477741)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->