### PR TITLE
chore: add executing-side resilience hooks (no-push-to-main, pre-push gates, branch-base helper)

### DIFF
--- a/.engram/hooks/README.md
+++ b/.engram/hooks/README.md
@@ -1,0 +1,74 @@
+# Engram Git Hooks
+
+Mechanical enforcement layer for Engram's development runbooks. Hooks live here
+and are shared via version control; they are **opt-in per checkout**.
+
+## Activation (one-time per checkout)
+
+```bash
+git config core.hooksPath .engram/hooks
+```
+
+That's it. All contributors on the same checkout then share the same guards.
+
+---
+
+## Hooks
+
+### `pre-push`
+
+Runs automatically on `git push`. Enforces three gates in order:
+
+1. **No direct push to `main`** — aborts immediately with a message directing
+   you to open a PR. See the three-layer enforcement section in either runbook.
+2. **Lint gate** — runs `ruff check --select=F401,F821` over `python/`, `test/`,
+   `benchmark/`, and `examples/`. Aborts on first failure.
+3. **CPU-only test gate** — runs `pytest -q test/srt/cpu/`. This is the
+   canonical CPU-runnable kernel test suite sourced from `.github/workflows/pr-test-xeon.yml`
+   and the `suite_xeon` definition in `test/srt/run_suite.py`. Aborts on failure.
+
+> **Do NOT call `pre-commit` from this hook.** The pre-commit binary in the
+> engram venv has a stale shebang pointing to the deleted `sglang-mamba` path
+> (tracked in KHA-400). Lint and tests are invoked directly instead.
+
+### `start-feature.sh`
+
+Helper script (not a Git-triggered hook) for starting feature or fix branches
+off a fresh `origin/main`.
+
+```bash
+.engram/hooks/start-feature.sh feat/my-feature
+.engram/hooks/start-feature.sh fix/kha-123-crash
+.engram/hooks/start-feature.sh chore/update-deps
+```
+
+**What it does:**
+- Validates the slug matches `(feat|fix|chore)/[a-z0-9-]+`
+- Refuses to run if the branch already exists locally or on `origin` (prevents
+  accidental clobber)
+- Fetches `origin main`, creates the branch off `origin/main`, and prints the
+  base commit SHA
+
+---
+
+## `--no-verify` Escape Hatch
+
+```bash
+git push --no-verify
+```
+
+Skips the pre-push hook entirely. Use only when:
+- You're pushing a work-in-progress branch with known lint failures you'll fix
+  before merging
+- CI already covers the same gates and local test infra is unavailable
+
+Do **not** use `--no-verify` on anything that goes to main.
+
+---
+
+## Runbook Cross-References
+
+These hooks implement the **mechanical enforcement layer** described in:
+
+- [Engram Feature & Issue Runbook — Three-Layer Enforcement](https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279)
+- [Engram Upstream Merge Runbook — Three-Layer Enforcement](https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc)

--- a/.engram/hooks/pre-push
+++ b/.engram/hooks/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# pre-push: blocks direct pushes to main; runs lint + CPU-only tests before push.
+# Activate: git config core.hooksPath .engram/hooks
+# Escape hatch: git push --no-verify  (logs a warning to stderr)
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── Gate 1: block direct push to main ───────────────────────────────────────
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+    if [[ "$remote_ref" == "refs/heads/main" ]]; then
+        echo >&2 ""
+        echo >&2 "ERROR: Direct push to main is blocked. Open a PR instead."
+        echo >&2 "       See engineering/engram/FEATURE_RUNBOOK.md or merges/ENGRAM_MERGE_RUNBOOK.md."
+        echo >&2 ""
+        exit 1
+    fi
+done
+
+# ── Gate 2: lint (ruff F401/F821) ───────────────────────────────────────────
+echo "pre-push: running ruff lint check..."
+if ! python -m ruff check --select=F401,F821 python/ test/ benchmark/ examples/ 2>&1; then
+    echo >&2 ""
+    echo >&2 "GATE FAILED: ruff lint. Fix the errors above, then push again."
+    echo >&2 "             (git push --no-verify to bypass — use sparingly)"
+    echo >&2 ""
+    exit 1
+fi
+echo "pre-push: ruff passed."
+
+# ── Gate 3: CPU-only tests ───────────────────────────────────────────────────
+# test/srt/cpu/ is the canonical CPU-runnable kernel test suite (sourced from
+# pr-test-xeon.yml and suite_xeon in test/srt/run_suite.py).
+# Do NOT call pre-commit; its venv shebang may point to a deleted path (KHA-400).
+echo "pre-push: running CPU-only tests (test/srt/cpu/)..."
+if ! python -m pytest -q test/srt/cpu/ 2>&1; then
+    echo >&2 ""
+    echo >&2 "GATE FAILED: pytest test/srt/cpu/. Fix the failures above, then push again."
+    echo >&2 "             (git push --no-verify to bypass — use sparingly)"
+    echo >&2 ""
+    exit 1
+fi
+echo "pre-push: CPU tests passed."
+
+echo "pre-push: all gates passed. Pushing..."
+exit 0

--- a/.engram/hooks/start-feature.sh
+++ b/.engram/hooks/start-feature.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# start-feature.sh: create a feature branch off the latest origin/main.
+# Usage: .engram/hooks/start-feature.sh <type>/<slug>
+#   e.g. .engram/hooks/start-feature.sh feat/snapshot-keying
+set -euo pipefail
+
+BRANCH="${1-}"
+
+if [[ -z "$BRANCH" ]]; then
+    echo >&2 "Usage: $0 <type>/<slug>   (e.g. feat/snapshot-keying)"
+    exit 1
+fi
+
+if ! [[ "$BRANCH" =~ ^(feat|fix|chore)/[a-z0-9-]+$ ]]; then
+    echo >&2 "ERROR: Branch name '${BRANCH}' is invalid."
+    echo >&2 "       Must match (feat|fix|chore)/[a-z0-9-]+  — e.g. feat/my-feature"
+    exit 1
+fi
+
+# Refuse to clobber an existing local branch
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    echo >&2 "ERROR: Branch '${BRANCH}' already exists locally. Choose a different name."
+    exit 1
+fi
+
+# Refuse to clobber an existing remote branch
+git fetch origin --quiet
+if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
+    echo >&2 "ERROR: Branch '${BRANCH}' already exists on origin. Choose a different name."
+    exit 1
+fi
+
+BASE_SHA="$(git rev-parse --short origin/main)"
+git checkout -b "${BRANCH}" origin/main
+
+echo ""
+echo "Branch : ${BRANCH}"
+echo "Base   : ${BASE_SHA}  (origin/main)"
+echo ""
+echo "Next steps:"
+echo "  git push -u origin ${BRANCH}"
+echo "  Open a PR when ready — do not push directly to main."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,22 @@ historical reference only.
 - Project skill files under `.claude/skills/` are intended to help agents work
   inside this repository
 
+## Git Hooks
+
+Mechanical enforcement is provided by the hooks in `.engram/hooks/`. Activate
+once per checkout:
+
+```bash
+git config core.hooksPath .engram/hooks
+```
+
+- **`pre-push`** — blocks direct pushes to `main`; runs ruff lint and
+  `pytest test/srt/cpu/` before every push.
+- **`start-feature.sh`** — creates a branch off `origin/main` with slug
+  validation and clobber protection. Usage: `.engram/hooks/start-feature.sh feat/my-feature`
+
+See `.engram/hooks/README.md` for full details and the `--no-verify` escape hatch.
+
 ## Protected Path Policy
 
 - The source of truth for protected files is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,18 @@ If `.claude/local-notes.md` exists, it may contain local maintainer preferences
 or environment details. Treat it as local-only context, not public project
 policy.
 
+## Git Hooks
+
+Git hooks live in `.engram/hooks/` and activate with one command per checkout:
+
+```bash
+git config core.hooksPath .engram/hooks
+```
+
+The `pre-push` hook blocks direct pushes to `main` and runs ruff + CPU-only
+tests before any push. `start-feature.sh` creates properly-based branches.
+See `.engram/hooks/README.md` for full usage.
+
 ## Protected Paths
 
 Protected-path policy lives in `.engram/policy/protected-paths.json`.


### PR DESCRIPTION
## Summary

Adds executing-side resilience hooks in `.engram/hooks/`:

- **`pre-push`** — blocks pushes to `refs/heads/main`; runs `ruff check --select=F401,F821` and `pytest -q test/srt/cpu/` before allowing other pushes.
- **`start-feature.sh`** — Phase 1 helper that creates a feature branch off latest `origin/main`, validates the slug, prints the base SHA.
- **`README.md`** — one-line activation instructions, hook descriptions, `--no-verify` escape-hatch guidance.

Activation is opt-in per checkout: `git config core.hooksPath .engram/hooks`.
Updates `AGENTS.md` and `CLAUDE.md` to mention the hooks and the activation command.

## Acceptance Criteria

- [ ] `git push origin main:main` blocked with the documented message
- [ ] Feature-branch push runs lint + CPU tests, aborts on failure (logic verified; first real exercise on push after activation)
- [ ] `start-feature.sh feat/<slug>` creates branch off latest `origin/main` and prints base SHA
- [ ] Both scripts parse cleanly (`bash -n`)

## Reference

- Feature & Issue Runbook: https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279
- Engram Upstream Merge Runbook: https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc

Both runbooks' "Three-layer enforcement" section names this PR's content (the mechanical layer).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26429582111](https://github.com/Clarit-AI/Engram/actions/runs/26429582111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26429616385](https://github.com/Clarit-AI/Engram/actions/runs/26429616385)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->