### PR TITLE
chore: add engram-brief-contract Claude Code skill

### DIFF
--- a/.claude/skills/engram-brief-contract/SKILL.md
+++ b/.claude/skills/engram-brief-contract/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: engram-brief-contract
+description: >
+  Triggers when the executing agent receives a markdown brief matching the
+  5-part format (Objective / Context / Steps / Expected outputs / Report back),
+  or when the user says "follow the brief," "use the runbook contract," "report
+  back per contract," or when a cross-machine handoff is in progress ("push
+  branch," "fetch first," "consumer brief"). Applies to all work in the engram
+  repo. Does NOT trigger on conversational requests that do not include a brief
+  block.
+---
+
+# engram-brief-contract
+
+## Purpose
+
+This skill enforces the canonical brief format and report-back contract used in
+the Engram runbooks. It applies to **both** feature/issue work and upstream
+merge work — the 2026-05-25 runbook updates reconciled both into single
+definitions shared here. The skill does **not** pick which runbook applies;
+runbook selection is overseer-driven. The executing agent infers from the
+brief's content which report-back contract to follow (feature 6-item vs. merge
+9-item). Feature is the default; merge applies only if the brief explicitly
+references upstream-sync or upstream-merge work.
+
+---
+
+## 5-Part Brief Contract
+
+A well-formed brief must contain exactly these five sections in order:
+
+1. **Objective** — one sentence.
+2. **Context** — only what the agent needs. If codebase context is required,
+   the overseer pastes the relevant excerpt; the overseer does not fetch source.
+3. **Exact commands or steps.**
+4. **Expected outputs** — including acceptance criteria as the definition of
+   done.
+5. **Required report-back section** (see below).
+
+If you receive a brief that is missing any of these sections, flag the gap
+before starting work. Do not invent missing context.
+
+---
+
+## Cross-Machine Discipline
+
+The producing agent **pushes its branch to origin** before handing off. The
+consuming brief opens with a **fetch + branch-exists check** before any compute
+spend. If the branch is absent on origin, stop and report the missing branch
+rather than reconstructing work from scratch.
+
+---
+
+## Report-Back Contracts
+
+### Which one applies?
+
+- **Feature 6-item** — default for all feature, fix, chore, and issue work.
+- **Merge 9-item** — use only when the brief explicitly concerns an upstream
+  sync or upstream merge (references the merge runbook, Phase 4, or
+  `upstream/main`).
+
+---
+
+### Feature / Issue / Bugfix — 6-Item Report-Back
+
+1. **Outputs produced** — files, PR URL, artifacts.
+2. **Commands run and exit codes.**
+3. **Deviations from the brief**, if any.
+4. **Quality-gate self-assessment** — syntax, types, lint, tests (pass/fail
+   each).
+5. **Acceptance-criteria pass/fail** — per criterion listed in the brief.
+6. **Contract gate result** — pass / fail / skip-recorded-as-KHA-405-finding,
+   or "n/a — contract surface not touched."
+
+---
+
+### Upstream Merge — 9-Item Report-Back
+
+1. **PR URL.**
+2. **Validation script output** — pass/fail for each of the 6 tests, including
+   test #6 contract-conformance.
+3. **Final conflict count** — expected vs. actual.
+4. **Any `ENGRAM_CONFLICT_REVIEW` markers** that need human attention (post-merge
+   grep output).
+5. **Any new upstream CI workflows** that were fork-guarded, and whether they
+   were added to `protected-paths.json`.
+6. **Updated header count and block count** post-merge (broad scope; compare to
+   manifest).
+7. **Any files from the manifest's "Deleted Files" section** that appeared as
+   conflicts and how you resolved them (should always be `git rm`).
+8. **Wheel uploaded to S3?** — URL or "skipped — used hosted wheel."
+9. **Contract gate result** (test #6) — pass / fail /
+   skip-recorded-as-KHA-405-finding (with link).
+
+---
+
+## Linear Canonicals
+
+- Feature & Issue Runbook: https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279
+- Upstream Merge Runbook: https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,16 @@ historical reference only.
 - Project skill files under `.claude/skills/` are intended to help agents work
   inside this repository
 
+## Agent Skills
+
+Skills live in `.claude/skills/`. Invoke them via the `Skill` tool.
+
+- **`engram-brief-contract`** (`.claude/skills/engram-brief-contract/SKILL.md`)
+  — Enforces the canonical 5-part brief format and report-back contracts from
+  the Linear runbooks. Applies to feature/issue work (6-item report-back) and
+  upstream merge work (9-item report-back). Triggers when an agent receives a
+  structured brief or when the user references the runbook contract.
+
 ## Git Hooks
 
 Mechanical enforcement is provided by the hooks in `.engram/hooks/`. Activate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,15 @@ The `pre-push` hook blocks direct pushes to `main` and runs ruff + CPU-only
 tests before any push. `start-feature.sh` creates properly-based branches.
 See `.engram/hooks/README.md` for full usage.
 
+## Agent Skills
+
+Skills live in `.claude/skills/` and are invoked via the `Skill` tool.
+
+- **`engram-brief-contract`** — Enforces the canonical 5-part brief format and
+  report-back contracts from the Linear runbooks. Applies universally to feature
+  work (6-item report-back) and upstream merge work (9-item report-back). See
+  `.claude/skills/engram-brief-contract/SKILL.md`.
+
 ## Protected Paths
 
 Protected-path policy lives in `.engram/policy/protected-paths.json`.


### PR DESCRIPTION
## Summary

Adds `.claude/skills/engram-brief-contract/SKILL.md` — a Claude Code skill that enforces the canonical brief format and report-back contract from the Linear runbooks for executing-agent work. Universal across feature work and upstream merges; does not pick which runbook applies.

Skill body covers:

- 5-part brief contract (Objective / Context / Steps / Expected outputs / Report-back) verbatim from the runbooks
- Cross-machine discipline (producer pushes branch; consumer fetches first)
- Both report-back contracts: 6-item universal and 9-item merge-augmented
- Guidance on which applies (default feature; merge only when the brief is about an upstream sync)
- Note: skill enforces shared format, does not pick a runbook
- Links to both Linear canonicals

Updates `AGENTS.md` and `CLAUDE.md` to reference the skill.

## Acceptance Criteria

- [ ] `SKILL.md` frontmatter parses as valid YAML
- [ ] Skill body contains the 5-part brief contract, cross-machine rule, and both report-back contracts verbatim
- [ ] Trigger description explicitly anti-triggers on conversational requests without a brief block

## Reference

- Feature & Issue Runbook: https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279
- Engram Upstream Merge Runbook: https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc

Process layer of the runbooks' three-layer enforcement model.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26429968178](https://github.com/Clarit-AI/Engram/actions/runs/26429968178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26429968099](https://github.com/Clarit-AI/Engram/actions/runs/26429968099)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->