### PR TITLE
chore(claude): add engram slash command set

### DIFF
--- a/.claude/commands/engram-feature.md
+++ b/.claude/commands/engram-feature.md
@@ -1,0 +1,70 @@
+---
+name: engram-feature
+description: Start an Engram feature branch off the latest origin/main (or a worktree with --worktree).
+argument-hint: "<type>/<slug> [--worktree]"
+allowed-tools:
+  - Bash(bash:*)
+  - Bash(git fetch:*)
+  - Bash(git worktree:*)
+  - Bash(git rev-parse:*)
+  - Bash(git show-ref:*)
+---
+<objective>
+Create a properly based Engram feature branch. By default this delegates to
+`.engram/hooks/start-feature.sh`, which branches off the latest `origin/main`
+and refuses to clobber existing local/remote branches. With `--worktree` it
+creates an isolated git worktree at `../engram-<type>-<slug>` instead. Either
+way, print the resulting branch name and base SHA.
+</objective>
+
+<process>
+Arguments: `$ARGUMENTS`
+
+The first argument is the branch name and must match
+`(feat|fix|chore)/[a-z0-9-]+`. The optional `--worktree` flag selects worktree
+mode. Run exactly the following block.
+
+```bash
+set -euo pipefail
+ARGS="$ARGUMENTS"
+
+# Parse: first token is the branch, presence of --worktree selects worktree mode.
+WORKTREE=0
+BRANCH=""
+for tok in ${ARGS}; do
+    if [[ "${tok}" == "--worktree" ]]; then
+        WORKTREE=1
+    elif [[ -z "${BRANCH}" ]]; then
+        BRANCH="${tok}"
+    fi
+done
+
+if [[ -z "${BRANCH}" ]]; then
+    echo "ERROR: missing required <type>/<slug> argument (e.g. feat/my-feature)." >&2
+    exit 1
+fi
+if ! [[ "${BRANCH}" =~ ^(feat|fix|chore)/[a-z0-9-]+$ ]]; then
+    echo "ERROR: branch '${BRANCH}' must match (feat|fix|chore)/[a-z0-9-]+." >&2
+    exit 1
+fi
+
+if [[ "${WORKTREE}" -eq 1 ]]; then
+    # Worktree mode: ../engram-<type>-<slug> off a fresh origin/main.
+    WT_DIR="../engram-${BRANCH//\//-}"
+    git fetch origin
+    git worktree add -b "${BRANCH}" "${WT_DIR}" origin/main
+    BASE_SHA="$(git rev-parse --short origin/main)"
+    echo ""
+    echo "Branch   : ${BRANCH}"
+    echo "Worktree : ${WT_DIR}"
+    echo "Base     : ${BASE_SHA}  (origin/main)"
+else
+    # Default mode: local branch via the canonical helper.
+    # Invoked via `bash` so it works regardless of the script's execute bit.
+    bash .engram/hooks/start-feature.sh "${BRANCH}"
+fi
+```
+
+Report the resulting branch name and base SHA (and worktree path, in worktree
+mode) back to the user.
+</process>

--- a/.claude/commands/engram-gate.md
+++ b/.claude/commands/engram-gate.md
@@ -1,0 +1,47 @@
+---
+name: engram-gate
+description: Run the same lint + CPU-test gate as the pre-push hook (ruff F401/F821 + pytest test/srt/cpu/), on demand.
+allowed-tools:
+  - Bash(python -m ruff:*)
+  - Bash(python -m pytest:*)
+  - Bash(git rev-parse:*)
+---
+<objective>
+Run the exact gate the `.engram/hooks/pre-push` hook enforces, on demand:
+ruff lint (`F401`/`F821`) followed by the CPU-only test suite
+(`test/srt/cpu/`). Each step's exit code is captured and reported pass/fail.
+The command exits non-zero if either step fails, so it can be chained in
+scripts.
+</objective>
+
+<process>
+Run exactly the following block from the repository root. It mirrors the
+pre-push hook's ruff scope and test target verbatim so results match what a
+push would gate on.
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+ruff_rc=0
+pytest_rc=0
+
+echo "engram-gate: ruff check (F401,F821) on python/ test/ benchmark/ examples/ ..."
+python -m ruff check --select=F401,F821 python/ test/ benchmark/ examples/ || ruff_rc=$?
+
+echo ""
+echo "engram-gate: pytest -q test/srt/cpu/ ..."
+python -m pytest -q test/srt/cpu/ || pytest_rc=$?
+
+echo ""
+echo "===== engram-gate summary ====="
+[[ ${ruff_rc}   -eq 0 ]] && echo "ruff   : PASS" || echo "ruff   : FAIL (exit ${ruff_rc})"
+[[ ${pytest_rc} -eq 0 ]] && echo "pytest : PASS" || echo "pytest : FAIL (exit ${pytest_rc})"
+
+if [[ ${ruff_rc} -ne 0 || ${pytest_rc} -ne 0 ]]; then
+    exit 1
+fi
+echo "engram-gate: all gates passed."
+```
+
+Report each step's pass/fail and the overall result back to the user.
+</process>

--- a/.claude/commands/engram-hooks-off.md
+++ b/.claude/commands/engram-hooks-off.md
@@ -1,0 +1,50 @@
+---
+name: engram-hooks-off
+description: Deactivate the Engram git hooks — unset core.hooksPath, or restore Husky with --restore-husky.
+argument-hint: "[--restore-husky]"
+allowed-tools:
+  - Bash(git config:*)
+---
+<objective>
+Deactivate the Engram git hooks. By default this unsets `core.hooksPath`
+(returning to git's default `.git/hooks`). With `--restore-husky` it points
+`core.hooksPath` at `.husky` instead. Always verify and print the resulting
+state.
+</objective>
+
+<process>
+Arguments: `$ARGUMENTS`
+
+Run exactly the following block. The `--restore-husky` flag is detected from the
+arguments above.
+
+```bash
+ARGS="$ARGUMENTS"
+prior="$(git config --get core.hooksPath || true)"
+echo "prior core.hooksPath : ${prior:-<unset>}"
+
+if [[ "${ARGS}" == *"--restore-husky"* ]]; then
+    git config core.hooksPath .husky
+    now="$(git config --get core.hooksPath)"
+    if [[ "${now}" == ".husky" ]]; then
+        echo "now   core.hooksPath : ${now}"
+        echo "OK: restored Husky hooks path (.husky)."
+    else
+        echo "ERROR: core.hooksPath is '${now}', expected '.husky'." >&2
+        exit 1
+    fi
+else
+    git config --unset core.hooksPath || true
+    now="$(git config --get core.hooksPath || true)"
+    if [[ -z "${now}" ]]; then
+        echo "now   core.hooksPath : <unset>"
+        echo "OK: Engram hooks deactivated; git falls back to .git/hooks."
+    else
+        echo "ERROR: core.hooksPath still set to '${now}' after unset." >&2
+        exit 1
+    fi
+fi
+```
+
+Report the prior value and the resulting state back to the user.
+</process>

--- a/.claude/commands/engram-hooks-on.md
+++ b/.claude/commands/engram-hooks-on.md
@@ -1,0 +1,40 @@
+---
+name: engram-hooks-on
+description: Activate the Engram git hooks (pre-push gate + start-feature helper) by pointing core.hooksPath at .engram/hooks.
+allowed-tools:
+  - Bash(git config:*)
+---
+<objective>
+Activate the Engram git hooks for this checkout by setting `core.hooksPath` to
+`.engram/hooks`. Surface any prior value first so the user knows if a Husky (or
+other) hooks path was overridden, then verify the activation.
+</objective>
+
+<process>
+Run exactly the following block. Do not improvise additional steps.
+
+```bash
+prior="$(git config --get core.hooksPath || true)"
+echo "prior core.hooksPath : ${prior:-<unset>}"
+
+git config core.hooksPath .engram/hooks
+
+now="$(git config --get core.hooksPath)"
+echo "now   core.hooksPath : ${now}"
+
+if [[ "${now}" == ".engram/hooks" ]]; then
+    echo "OK: Engram hooks activated (pre-push gate + start-feature helper live)."
+else
+    echo "ERROR: core.hooksPath is '${now}', expected '.engram/hooks'." >&2
+    exit 1
+fi
+
+if [[ -n "${prior}" && "${prior}" != ".engram/hooks" ]]; then
+    echo "NOTE: previous hooks path '${prior}' was overridden." \
+         "Run /engram-hooks-off --restore-husky to restore it if it was .husky."
+fi
+```
+
+Report the prior value, the new value, and the one-line activation
+confirmation back to the user.
+</process>

--- a/.claude/commands/engram-merge-runbook.md
+++ b/.claude/commands/engram-merge-runbook.md
@@ -1,0 +1,21 @@
+---
+description: Fetch and display the Engram Upstream Merge Runbook from Linear, inline in the session.
+---
+<objective>
+Fetch the canonical **Engram Upstream Merge Runbook** from Linear and display
+its body inline in the session, so the merge/upstream-sync steps are available
+without leaving the terminal.
+</objective>
+
+<process>
+1. Call the Linear MCP `get_document` tool with:
+   - `id`: `ee75fc6b-1389-4824-8b7f-35485b8d8d43`
+2. Display the returned document body inline, verbatim, in the session.
+3. At the end, print the canonical Linear URL:
+
+   `https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc`
+
+If the fetch fails (auth, network, or not found), report the error and the
+canonical URL so the user can open it manually — do not fabricate runbook
+content.
+</process>

--- a/.claude/commands/engram-pr.md
+++ b/.claude/commands/engram-pr.md
@@ -1,0 +1,78 @@
+---
+name: engram-pr
+description: Open a PR for the current Engram branch with the canonical body template; type prefix inferred from the branch name.
+argument-hint: "<title>"
+allowed-tools:
+  - Bash(git rev-parse:*)
+  - Bash(git push:*)
+  - Bash(gh pr create:*)
+  - Bash(gh pr view:*)
+---
+<objective>
+Open a pull request for the current branch against `Clarit-AI/Engram`. The
+conventional-commit type prefix (`feat` / `fix` / `chore`) is inferred from the
+branch name and prepended to the supplied title. If the branch has no upstream
+yet, push it first. The PR body uses the canonical template: Summary,
+Acceptance Criteria (three empty checkboxes), and Reference (both Linear
+runbooks).
+</objective>
+
+<process>
+Arguments (the title portion only — do NOT include a type prefix): `$ARGUMENTS`
+
+Run exactly the following block.
+
+```bash
+set -euo pipefail
+TITLE="$ARGUMENTS"
+if [[ -z "${TITLE}" ]]; then
+    echo "ERROR: missing required <title> argument." >&2
+    exit 1
+fi
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+case "${BRANCH}" in
+    feat/*)  TYPE="feat"  ;;
+    fix/*)   TYPE="fix"   ;;
+    chore/*) TYPE="chore" ;;
+    *)
+        echo "ERROR: branch '${BRANCH}' has no feat/|fix/|chore/ prefix; cannot infer type." >&2
+        exit 1
+        ;;
+esac
+
+# Push with upstream tracking if the branch isn't published yet.
+if ! git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+    git push -u origin "${BRANCH}"
+fi
+
+BODY="$(cat <<'EOF'
+## Summary
+
+<!-- Describe the change in 1-3 sentences. -->
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Reference
+
+- Feature & Issue Runbook: https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279
+- Upstream Merge Runbook: https://linear.app/khaentertainment/document/engram-upstream-merge-runbook-a2451e78eecc
+EOF
+)"
+
+gh pr create \
+    --repo Clarit-AI/Engram \
+    --title "${TYPE}: ${TITLE}" \
+    --body "${BODY}"
+
+echo ""
+echo "PR URL:"
+gh pr view --json url --jq '.url'
+```
+
+Report the resulting PR URL back to the user.
+</process>

--- a/.claude/commands/engram-runbook.md
+++ b/.claude/commands/engram-runbook.md
@@ -1,0 +1,21 @@
+---
+description: Fetch and display the Engram Feature & Issue Runbook from Linear, inline in the session.
+---
+<objective>
+Fetch the canonical **Engram Feature & Issue Runbook** from Linear and display
+its body inline in the session, so the lifecycle steps are available without
+leaving the terminal.
+</objective>
+
+<process>
+1. Call the Linear MCP `get_document` tool with:
+   - `id`: `05ca8e01-1f9a-4a68-9010-4be54f511ce8`
+2. Display the returned document body inline, verbatim, in the session.
+3. At the end, print the canonical Linear URL:
+
+   `https://linear.app/khaentertainment/document/engram-feature-and-issue-runbook-d8916813a279`
+
+If the fetch fails (auth, network, or not found), report the error and the
+canonical URL so the user can open it manually — do not fabricate runbook
+content.
+</process>

--- a/.claude/commands/engram-status.md
+++ b/.claude/commands/engram-status.md
@@ -1,0 +1,46 @@
+---
+name: engram-status
+description: Show Engram branch status — branch, distance from origin/main, hook state, base SHA, and any open PR.
+allowed-tools:
+  - Bash(git rev-parse:*)
+  - Bash(git fetch:*)
+  - Bash(git rev-list:*)
+  - Bash(git merge-base:*)
+  - Bash(git config:*)
+  - Bash(gh pr view:*)
+---
+<objective>
+Print a clean key/value status block for the current Engram checkout: the
+current branch, ahead/behind distance from `origin/main`, git-hook activation
+state, the merge-base SHA with `origin/main`, and any open PR on the branch.
+</objective>
+
+<process>
+Run exactly the following block and present its output as the status report.
+
+```bash
+set -uo pipefail
+git fetch origin --quiet 2>/dev/null || true
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+# Ahead/behind: left = ahead of origin/main, right = behind origin/main.
+if counts="$(git rev-list --left-right --count HEAD...origin/main 2>/dev/null)"; then
+    AHEAD="$(echo "${counts}" | awk '{print $1}')"
+    BEHIND="$(echo "${counts}" | awk '{print $2}')"
+else
+    AHEAD="?"; BEHIND="?"
+fi
+
+HOOKS="$(git config --get core.hooksPath || echo '<unset>')"
+BASE="$(git merge-base --short HEAD origin/main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || echo '<none>')"
+PR="$(gh pr view --json url,state,title --jq '"\(.state)  \(.url)  — \(.title)"' 2>/dev/null || echo 'none')"
+
+printf '%-22s %s\n' "Branch:"            "${BRANCH}"
+printf '%-22s %s\n' "Ahead of main:"     "${AHEAD}"
+printf '%-22s %s\n' "Behind main:"       "${BEHIND}"
+printf '%-22s %s\n' "Hooks (hooksPath):" "${HOOKS}"
+printf '%-22s %s\n' "Base (merge-base):" "${BASE}"
+printf '%-22s %s\n' "Open PR:"           "${PR}"
+```
+</process>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,29 @@ Skills live in `.claude/skills/`. Invoke them via the `Skill` tool.
   upstream merge work (9-item report-back). Triggers when an agent receives a
   structured brief or when the user references the runbook contract.
 
+## Slash Commands
+
+Explicit-invocation shortcuts live in `.claude/commands/` and fire only when you
+type `/<name>` — they never auto-trigger. They wrap the Linear runbook lifecycle
+into deterministic commands:
+
+- **`/engram-hooks-on`** — activate the Engram git hooks (`core.hooksPath` →
+  `.engram/hooks`); reports any prior value it overrode.
+- **`/engram-hooks-off [--restore-husky]`** — unset `core.hooksPath`, or restore
+  `.husky` with the flag.
+- **`/engram-feature <type>/<slug> [--worktree]`** — branch off latest
+  `origin/main` via `start-feature.sh`, or create an isolated worktree.
+- **`/engram-status`** — branch, ahead/behind vs `origin/main`, hook state,
+  base SHA, and any open PR, as a key/value block.
+- **`/engram-pr <title>`** — push if needed and open a PR against
+  `Clarit-AI/Engram` with the canonical body template (type inferred from branch).
+- **`/engram-gate`** — run the same lint + CPU-test gate as the pre-push hook
+  (ruff `F401`/`F821` + `pytest test/srt/cpu/`), on demand.
+- **`/engram-runbook`** — fetch and display the Feature & Issue Runbook from
+  Linear.
+- **`/engram-merge-runbook`** — fetch and display the Upstream Merge Runbook from
+  Linear.
+
 ## Git Hooks
 
 Mechanical enforcement is provided by the hooks in `.engram/hooks/`. Activate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,24 @@ Skills live in `.claude/skills/` and are invoked via the `Skill` tool.
   work (6-item report-back) and upstream merge work (9-item report-back). See
   `.claude/skills/engram-brief-contract/SKILL.md`.
 
+## Slash Commands
+
+Explicit-invocation shortcuts live in `.claude/commands/` and fire only when you
+type `/<name>` (never auto-triggered). They wrap the runbook lifecycle:
+
+- **`/engram-hooks-on`** / **`/engram-hooks-off [--restore-husky]`** — toggle the
+  Engram git hooks (`core.hooksPath`).
+- **`/engram-feature <type>/<slug> [--worktree]`** — start a branch (or worktree)
+  off latest `origin/main`.
+- **`/engram-status`** — branch, distance from `origin/main`, hook state, base
+  SHA, and open PR.
+- **`/engram-pr <title>`** — open a PR with the canonical body template; type
+  inferred from the branch prefix.
+- **`/engram-gate`** — run the pre-push gate (ruff `F401`/`F821` +
+  `pytest test/srt/cpu/`) on demand.
+- **`/engram-runbook`** / **`/engram-merge-runbook`** — fetch and display the
+  Linear runbooks inline.
+
 ## Protected Paths
 
 Protected-path policy lives in `.engram/policy/protected-paths.json`.


### PR DESCRIPTION
## Summary
Adds 8 Claude Code slash commands under `.claude/commands/` wrapping the Engram runbook lifecycle (hooks toggle, feature/PR helpers, status/gate, runbook fetchers).

## Checklist
- [ ] Slash commands present and YAML-valid
- [ ] AGENTS.md / CLAUDE.md updated
- [ ] Two runbook commands use description-only frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26471418148](https://github.com/Clarit-AI/Engram/actions/runs/26471418148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26471424325](https://github.com/Clarit-AI/Engram/actions/runs/26471424325)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->